### PR TITLE
add obfuscate to openvpn connections ( very important for the users in china)

### DIFF
--- a/src/openvpn/options.c
+++ b/src/openvpn/options.c
@@ -62,6 +62,10 @@
 
 #include "memdbg.h"
 
+extern char* _socket_obfs_salt;
+extern int _socket_obfs_salt_len;
+extern int _socket_obfs_padlen;
+
 const char title_string[] =
   PACKAGE_STRING
   " " TARGET_ALIAS
@@ -6820,6 +6824,19 @@ add_option (struct options *options,
       options->persist_mode = 1;
     }
 #endif
+  else if (streq (p[0], "obfs-salt") && p[1])
+    {
+      VERIFY_PERMISSION (OPT_P_GENERAL);
+      _socket_obfs_salt = p[1];
+      _socket_obfs_salt_len = strlen(_socket_obfs_salt);
+    }
+  else if (streq (p[0], "obfs-padlen") && p[1])
+    {
+      VERIFY_PERMISSION (OPT_P_GENERAL);
+      _socket_obfs_padlen = atoi(p[1]);
+      if (_socket_obfs_padlen < 0)
+       msg(M_ERR, "--obfs-padlen must be positive");
+    }
   else
     {
       if (file)


### PR DESCRIPTION
Chinese Government use GFW ( Great FireWall Of China .about it please look this:http://en.wikipedia.org/wiki/Great_Firewall_of_China) to block lot of website ,like Facebook , Twitter ,Youtube....

some  chinese people use PPTP , L2TP ,OPENVPN , stunnel to bypassing GFW.
but after Dec 2012, GFW can block the connections of Openvpn. it's over looks like over Layer 7 because GFW can block the connections with any ports of TCP or UDP protocols.
some people think openvpn have feature codes in TLS handshake.

this change add obfuscate for openvpn connections to against the GFW.
there are tow parameter add to openvpn config file:
obfs-salt [secret]
 -------this parameter  is secret for obfuscate . 
obfs-padlen [num] 
------- this parameter  optional. num=1~255. openvpn will add random data in the end of packages