### PR TITLE
tls_ctx_load_ca: Improve certificate error messages

### DIFF
--- a/src/openvpn/ssl_openssl.c
+++ b/src/openvpn/ssl_openssl.c
@@ -693,7 +693,7 @@ tls_ctx_load_ca (struct tls_root_ctx *ctx, const char *ca_file,
   X509_STORE *store = NULL;
   X509_NAME *xn = NULL;
   BIO *in = NULL;
-  int i, added = 0;
+  int i, added = 0, prev = 0;
 
   ASSERT(NULL != ctx);
 
@@ -719,6 +719,11 @@ tls_ctx_load_ca (struct tls_root_ctx *ctx, const char *ca_file,
               X509_INFO *info = sk_X509_INFO_value (info_stack, i);
               if (info->crl)
                   X509_STORE_add_crl (store, info->crl);
+
+              if (tls_server && !info->x509)
+                {
+                  msg (M_SSLERR, "X509 name was missing in TLS mode");
+                }
 
               if (info->x509)
                 {
@@ -749,6 +754,15 @@ tls_ctx_load_ca (struct tls_root_ctx *ctx, const char *ca_file,
                       sk_X509_NAME_push (cert_names, xn);
                     }
                 }
+
+              if (tls_server) {
+                int cnum = sk_X509_NAME_num (cert_names);
+                if (cnum != (prev + 1)) {
+                  msg (M_WARN, "Cannot load CA certificate file %s (entry %d did not validate)", np(ca_file), added);
+                }
+                prev = cnum;
+              }
+
             }
           sk_X509_INFO_pop_free (info_stack, X509_INFO_free);
         }
@@ -756,8 +770,15 @@ tls_ctx_load_ca (struct tls_root_ctx *ctx, const char *ca_file,
       if (tls_server)
         SSL_CTX_set_client_CA_list (ctx->ctx, cert_names);
 
-      if (!added || (tls_server && sk_X509_NAME_num (cert_names) != added))
-        msg (M_SSLERR, "Cannot load CA certificate file %s", np(ca_file));
+      if (!added)
+        msg (M_SSLERR, "Cannot load CA certificate file %s (no entries were read)", np(ca_file));
+
+      if (tls_server) {
+        int cnum = sk_X509_NAME_num (cert_names);
+        if (cnum != added)
+          msg (M_SSLERR, "Cannot load CA certificate file %s (only %d of %d entries were valid X509 names)", np(ca_file), cnum, added);
+      }
+
       if (in)
         BIO_free (in);
     }


### PR DESCRIPTION
If a CA certificate file includes intermediate certificates, and any
of them fail to verify, the current code will file with "Cannot load
CA certificate file".  Instead, generate a more specific error message
identifying the specific sub-certificate(s) which did not validate.

I make no claim that I really understand the OpenVPN code, but here's the scenario that led to this patch:

I was using the "pile of certificates" handed to me by StartSSL, and one of them was expired, but unnecessary to the verification chain.  So when I tried to verify using openssl, it worked fine, but OpenVPN complained with a not-very-helpful "Cannot load CA certificate file."  The following patch was what I ended up doing to figure out what was going wrong.

I have the suspicion that there are more complex procedures for submitting a patch that I don't know about, but I figured I'd start like this to see if the change was interesting enough to you for me to pursue it further.