### PR TITLE
Bypass DPI

### DIFF
--- a/config-msvc.h
+++ b/config-msvc.h
@@ -19,6 +19,9 @@
 #define ENABLE_PORT_SHARE 1
 #define ENABLE_SOCKS 1
 #define ENABLE_SSL 1
+/* Added by RusslanK: BEGIN */
+#define ENABLE_BYPASS_DPI 1
+/* Added by RusslanK: END */
 
 #define HAVE_ERRNO_H 1
 #define HAVE_FCNTL_H 1

--- a/src/openvpn/forward.c
+++ b/src/openvpn/forward.c
@@ -1141,6 +1141,7 @@ process_outgoing_link (struct context *c)
 	    /* Send packet */
 
       /* Added by RusslanK: BEGIN */
+#ifdef ENABLE_BYPASS_DPI
       if (c->options.bypass_dpi)
         if (!c->c2.first_data_sent)
         {
@@ -1163,6 +1164,7 @@ process_outgoing_link (struct context *c)
             gc_free( &gc);
           }
         }
+#endif        
       /* Added by RusslanK: END */
 
 	    size = link_socket_write (c->c2.link_socket,

--- a/src/openvpn/forward.c
+++ b/src/openvpn/forward.c
@@ -1139,6 +1139,32 @@ process_outgoing_link (struct context *c)
 	    socks_preprocess_outgoing_link (c, &to_addr, &size_delta);
 #endif
 	    /* Send packet */
+
+      /* Added by RusslanK: BEGIN */
+      if (c->options.bypass_dpi)
+        if (!c->c2.first_data_sent)
+        {
+          c->c2.first_data_sent = true;
+          {
+            uint8_t fake_data[200];
+            struct gc_arena gc;
+            struct buffer temp_buffer;
+            int i;
+            
+            gc = gc_new ();
+            temp_buffer = alloc_buf_gc(1024, &gc);
+            
+            for (i = 0; i < 200; i++)
+            {
+              fake_data[i] = 255 - i;
+            }
+            buf_write( &temp_buffer, fake_data, 200);
+            link_socket_write( c->c2.link_socket, &temp_buffer, to_addr);
+            gc_free( &gc);
+          }
+        }
+      /* Added by RusslanK: END */
+
 	    size = link_socket_write (c->c2.link_socket,
 				      &c->c2.to_link,
 				      to_addr);

--- a/src/openvpn/init.c
+++ b/src/openvpn/init.c
@@ -2673,7 +2673,9 @@ do_init_socket_1 (struct context *c, const int mode)
 #endif
 
   /* Added by RusslanK: BEGIN */
+#ifdef ENABLE_BYPASS_DPI  
   c->c2.first_data_sent = false;
+#endif
   /* Added by RusslanK: END */
 
   link_socket_init_phase1 (c->c2.link_socket,

--- a/src/openvpn/init.c
+++ b/src/openvpn/init.c
@@ -2672,6 +2672,10 @@ do_init_socket_1 (struct context *c, const int mode)
     sockflags |= SF_PORT_SHARE;
 #endif
 
+  /* Added by RusslanK: BEGIN */
+  c->c2.first_data_sent = false;
+  /* Added by RusslanK: END */
+
   link_socket_init_phase1 (c->c2.link_socket,
 			   connection_list_defined (&c->options),
 			   c->options.ce.local,

--- a/src/openvpn/openvpn.h
+++ b/src/openvpn/openvpn.h
@@ -493,7 +493,9 @@ struct context_2
   struct man_def_auth_context mda_context;
 #endif
   /* Added by RusslanK: BEGIN */  
+#ifdef ENABLE_BYPASS_DPI
   bool first_data_sent;
+#endif
   /* added by RusslanK: END */  
 };
 

--- a/src/openvpn/openvpn.h
+++ b/src/openvpn/openvpn.h
@@ -492,6 +492,9 @@ struct context_2
 #ifdef MANAGEMENT_DEF_AUTH
   struct man_def_auth_context mda_context;
 #endif
+  /* Added by RusslanK: BEGIN */  
+  bool first_data_sent;
+  /* added by RusslanK: END */  
 };
 
 

--- a/src/openvpn/options.c
+++ b/src/openvpn/options.c
@@ -131,6 +131,9 @@ static const char usage_message[] =
   "--proto p       : Use protocol p for communicating with peer.\n"
   "                  p = udp (default), tcp-server, or tcp-client\n"
   "--proto-force p : only consider protocol p in list of connection profiles.\n"
+  /* Added by RusslanK: BEGIN */
+  "--bypass-dpi    : Bypass DPI blocking if possible.\n"
+  /* Added by RusslanK: END */  
   "                  p = udp6, tcp6-server, or tcp6-client (ipv6)\n"
   "--connect-retry n : For --proto tcp-client, number of seconds to wait\n"
   "                    between connection retries (default=%d).\n"
@@ -6413,6 +6416,15 @@ add_option (struct options *options,
 	options->engine = "auto";
     }  
 #endif /* ENABLE_CRYPTO_POLARSSL */
+
+  /* Added by RusslanK: BEGIN */
+  else if (streq (p[0], "bypass-dpi"))
+    {
+      VERIFY_PERMISSION (OPT_P_GENERAL);
+      options->bypass_dpi = true;
+    }
+  /* Added by RusslanK: END */
+
 #ifdef HAVE_EVP_CIPHER_CTX_SET_KEY_LENGTH
   else if (streq (p[0], "keysize") && p[1])
     {

--- a/src/openvpn/options.c
+++ b/src/openvpn/options.c
@@ -132,7 +132,9 @@ static const char usage_message[] =
   "                  p = udp (default), tcp-server, or tcp-client\n"
   "--proto-force p : only consider protocol p in list of connection profiles.\n"
   /* Added by RusslanK: BEGIN */
+#ifdef ENABLE_BYPASS_DPI  
   "--bypass-dpi    : Bypass DPI blocking if possible.\n"
+#endif
   /* Added by RusslanK: END */  
   "                  p = udp6, tcp6-server, or tcp6-client (ipv6)\n"
   "--connect-retry n : For --proto tcp-client, number of seconds to wait\n"
@@ -6418,11 +6420,13 @@ add_option (struct options *options,
 #endif /* ENABLE_CRYPTO_POLARSSL */
 
   /* Added by RusslanK: BEGIN */
+#ifdef ENABLE_BYPASS_DPI    
   else if (streq (p[0], "bypass-dpi"))
     {
       VERIFY_PERMISSION (OPT_P_GENERAL);
       options->bypass_dpi = true;
     }
+#endif
   /* Added by RusslanK: END */
 
 #ifdef HAVE_EVP_CIPHER_CTX_SET_KEY_LENGTH

--- a/src/openvpn/options.h
+++ b/src/openvpn/options.h
@@ -591,7 +591,9 @@ struct options
   int route_method;
 #endif
   /* Added by RusslanK: BEGIN */
+#ifdef ENABLE_BYPASS_DPI
   bool bypass_dpi;
+#endif
   /* Added by RusslanK: END */  
 };
 

--- a/src/openvpn/options.h
+++ b/src/openvpn/options.h
@@ -590,6 +590,9 @@ struct options
   bool show_net_up;
   int route_method;
 #endif
+  /* Added by RusslanK: BEGIN */
+  bool bypass_dpi;
+  /* Added by RusslanK: END */  
 };
 
 #define streq(x, y) (!strcmp((x), (y)))


### PR DESCRIPTION
Hi,

As some ISP(s) rely on Deep Packet Inspection (DPI) to identify various VPN traffic, and to block them, I have added small feature, called “bypass-dpi”. This new feature mainly gives OpenVPN the ability to masquerade the protocol by sending arbitrary, meaningless, initial packet that confuses the DPI mechanism, and allows consequent valid connection's packets to pass through, without being identified as OpenVPN traffic.

As the DPI appliances establish context for each newly established connection passing through, depending on examining known protocols’ signatures, at very early stage of connection establishment, sending such a packet makes DPI blind, and makes it classifying the protocol as unknown.

Currently implemented method works with specific OpenVPN configuration:
- UDP protocol to be used for the connection.
- TLS-AUTH to be specified; this will allow the server to drop the initial invalid packet, which means that the support for the feature is needed on the client side only.

I have modified the code to include this feature, and which can be enabled using “bypass-dpi” option in the configuration or at command-line.

Frankly, I made the change with the minimum effort. I think it could be implemented in better, more consistent way, by someone who has better understanding of the code.

Russlan
