### PR TITLE
Apple Mac OS X Keychain support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -330,6 +330,7 @@ case "$host" in
 		have_tap_header="yes"
 		dnl some Mac OS X tendering (we use vararg macros...)
 		CPPFLAGS="$CPPFLAGS -no-cpp-precomp"
+		MACOSX=yes
 		;;
 	*-mingw*)
 		AC_DEFINE([TARGET_WIN32], [1], [Are we running WIN32?])

--- a/configure.ac
+++ b/configure.ac
@@ -1166,6 +1166,7 @@ AC_SUBST([PLUGIN_AUTH_PAM_CFLAGS])
 AC_SUBST([PLUGIN_AUTH_PAM_LIBS])
 
 AM_CONDITIONAL([WIN32], [test "${WIN32}" = "yes"])
+AM_CONDITIONAL([MACOSX], [test "${MACOSX}" = "yes"])
 AM_CONDITIONAL([GIT_CHECKOUT], [test "${GIT_CHECKOUT}" = "yes"])
 AM_CONDITIONAL([ENABLE_PLUGIN_AUTH_PAM], [test "${enable_plugin_auth_pam}" = "yes"])
 AM_CONDITIONAL([ENABLE_PLUGIN_DOWN_ROOT], [test "${enable_plugin_down_root}" = "yes"])

--- a/doc/openvpn.8
+++ b/doc/openvpn.8
@@ -4430,6 +4430,64 @@ Certificate Store GUI.
 
 .\"*********************************************************
 .TP
+.B --keychaincert select-string
+Load the certificate and private key from the
+Mac OS X Keychain (Mac OS X Only).
+
+Use this option instead of
+.B --cert
+and
+.B --key.
+
+This makes it possible to use any smart card supported by Mac OS X using the tokend interface, but also any
+kind of certificate, residing in the Keychain, where you have access to
+the private key.  This option has been tested on the client side with an Aladdin eToken
+on Mac OS X Leopard and with software certificates stored in the Keychain on Mac OS X Leopard and
+Mac OS X Snow Leopard.  As of this writing (4/27/10) Aladdin has not yet released Snow Leopard drivers.
+
+To select a certificate based on a string search in the
+certificate's subject and/or issuer:
+
+.B keychaincert
+"SUBJECT:c=US/o=Apple Inc./ou=me.com/cn=username ISSUER:c=US/o=Apple Computer, Inc./ou=Apple Computer Certificate Authority/cn=Apple .Mac Certificate Authority"
+
+.I "Distinguished Name Component Abbreviations:" 
+.br
+o = organization
+.br
+ou = organizational unit
+.br
+c = country
+.br
+l = locality
+.br
+st = state
+.br
+cn = common name
+.br
+e = email
+.br
+
+All of the distinguished name components are optional, although you do need to specify at least one of them.  You can 
+add spaces around the '/' and '=' characters, e.g. "SUBJECT: c = US / o = Apple Inc.".  You do not need to specify
+both the subject and the issuer, one or the other will work fine.  The identity searching algorithm will return the first
+certificate it finds that matches all of the criteria you have specified.  You can also include the MD5 and/or SHA1 thumbprints 
+along with the subject and issuer (see example of thumbprint search criteria below).  
+
+To select a certificate based on certificate's MD5 or SHA1 thumbprint:
+
+.B keychaincert
+"SHA1: 30 F7 3A 7A B7 73 2A 98 54 33 4A A7 00 6F 6E AC EC D1 EF 02 MD5: D5 F5 11 F1 38 EB 5F 4D CF 23 B6 94 E8 33 D8 B5"
+
+Again, you can include both the SHA1 and the MD5 thumbprints, but you can also use just one of them.  The thumbprint hex
+strings can easily be copy-and-pasted from the OS X Keychain Access GUI in the Applications/Utilities folder.  The hex string comparison is
+not case sensitive.
+
+Note that this option cannot be used with the --daemon option.  Mac OS X needs to present the user with an authentication GUI when the Keychain
+is accessed by openvpn and the --daemon option will prevent the GUI from being shown and therefore cause the authentication to silently fail.
+
+.\"*********************************************************
+.TP
 .B \-\-key-method m
 Use data channel key negotiation method
 .B m.

--- a/src/openvpn/Makefile.am
+++ b/src/openvpn/Makefile.am
@@ -18,7 +18,7 @@ EXTRA_DIST = \
 	openvpn.vcxproj \
 	openvpn.vcxproj.filters
 
-INCLUDES = \
+AM_CPPFLAGS = \
 	-I$(top_srcdir)/include \
 	-I$(top_srcdir)/src/compat
 
@@ -116,7 +116,9 @@ openvpn_SOURCES = \
 	syshead.h \
 	tun.c tun.h \
 	win32.h win32.c \
-	cryptoapi.h cryptoapi.c
+	cryptoapi.h cryptoapi.c \
+	keychain.h keychain.c \
+	macosx.h macosx.c
 openvpn_LDADD = \
 	$(top_builddir)/src/compat/libcompat.la \
 	$(SOCKETS_LIBS) \
@@ -132,5 +134,5 @@ openvpn_SOURCES += openvpn_win32_resources.rc
 openvpn_LDADD += -lgdi32 -lws2_32 -lwininet -lcrypt32 -liphlpapi -lwinmm
 endif
 if MACOSX
-openvpn_LDADD += -framework CoreFoundation -framework Security
+openvpn_LDFLAGS = -framework CoreFoundation -framework Security
 endif

--- a/src/openvpn/Makefile.am
+++ b/src/openvpn/Makefile.am
@@ -131,3 +131,6 @@ if WIN32
 openvpn_SOURCES += openvpn_win32_resources.rc
 openvpn_LDADD += -lgdi32 -lws2_32 -lwininet -lcrypt32 -liphlpapi -lwinmm
 endif
+if MACOSX
+openvpn_LDADD += -framework CoreFoundation -framework Security
+endif

--- a/src/openvpn/cryptoapi.c
+++ b/src/openvpn/cryptoapi.c
@@ -82,384 +82,428 @@
 #define CRYPTOAPI_F_GET_PROC_ADDRESS			    108
 
 static ERR_STRING_DATA CRYPTOAPI_str_functs[] =	{
-    { ERR_PACK(ERR_LIB_CRYPTOAPI, 0, 0),				    "microsoft cryptoapi"},
-    { ERR_PACK(0, CRYPTOAPI_F_CERT_OPEN_SYSTEM_STORE, 0),		    "CertOpenSystemStore" },
-    { ERR_PACK(0, CRYPTOAPI_F_CERT_FIND_CERTIFICATE_IN_STORE, 0),	    "CertFindCertificateInStore" },
-    { ERR_PACK(0, CRYPTOAPI_F_CRYPT_ACQUIRE_CERTIFICATE_PRIVATE_KEY, 0),    "CryptAcquireCertificatePrivateKey" },
-    { ERR_PACK(0, CRYPTOAPI_F_CRYPT_CREATE_HASH, 0),			    "CryptCreateHash" },
-    { ERR_PACK(0, CRYPTOAPI_F_CRYPT_GET_HASH_PARAM, 0),			    "CryptGetHashParam" },
-    { ERR_PACK(0, CRYPTOAPI_F_CRYPT_SET_HASH_PARAM, 0),			    "CryptSetHashParam" },
-    { ERR_PACK(0, CRYPTOAPI_F_CRYPT_SIGN_HASH, 0),			    "CryptSignHash" },
-    { ERR_PACK(0, CRYPTOAPI_F_LOAD_LIBRARY, 0),			    	    "LoadLibrary" },
-    { ERR_PACK(0, CRYPTOAPI_F_GET_PROC_ADDRESS, 0),			    "GetProcAddress" },
-    { 0, NULL }
+  { ERR_PACK(ERR_LIB_CRYPTOAPI, 0, 0),                                 "Microsoft CryptoAPI"},
+  { ERR_PACK(0, CRYPTOAPI_F_CERT_OPEN_SYSTEM_STORE, 0),                "CertOpenSystemStore" },
+  { ERR_PACK(0, CRYPTOAPI_F_CERT_FIND_CERTIFICATE_IN_STORE, 0),        "CertFindCertificateInStore" },
+  { ERR_PACK(0, CRYPTOAPI_F_CRYPT_ACQUIRE_CERTIFICATE_PRIVATE_KEY, 0), "CryptAcquireCertificatePrivateKey" },
+  { ERR_PACK(0, CRYPTOAPI_F_CRYPT_CREATE_HASH, 0),                     "CryptCreateHash" },
+  { ERR_PACK(0, CRYPTOAPI_F_CRYPT_GET_HASH_PARAM, 0),                  "CryptGetHashParam" },
+  { ERR_PACK(0, CRYPTOAPI_F_CRYPT_SET_HASH_PARAM, 0),                  "CryptSetHashParam" },
+  { ERR_PACK(0, CRYPTOAPI_F_CRYPT_SIGN_HASH, 0),                       "CryptSignHash" },
+  { ERR_PACK(0, CRYPTOAPI_F_LOAD_LIBRARY, 0),                          "LoadLibrary" },
+  { ERR_PACK(0, CRYPTOAPI_F_GET_PROC_ADDRESS, 0),                      "GetProcAddress" },
+  { 0, NULL }
 };
 
 typedef struct _CAPI_DATA {
-    const CERT_CONTEXT *cert_context;
-    HCRYPTPROV crypt_prov;
-    DWORD key_spec;
-    BOOL free_crypt_prov;
+  const CERT_CONTEXT *cert_context;
+  HCRYPTPROV crypt_prov;
+  DWORD key_spec;
+  BOOL free_crypt_prov;
 } CAPI_DATA;
 
-static char *ms_error_text(DWORD ms_err)
+static char
+*ms_error_text(DWORD ms_err)
 {
-    LPVOID lpMsgBuf = NULL;
-    char *rv = NULL;
+  LPVOID lpMsgBuf = NULL;
+  char *rv = NULL;
 
-    FormatMessage(
-	FORMAT_MESSAGE_ALLOCATE_BUFFER |
-	FORMAT_MESSAGE_FROM_SYSTEM |
-	FORMAT_MESSAGE_IGNORE_INSERTS,
-	NULL, ms_err,
-	MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), /* Default language */
-	(LPTSTR) &lpMsgBuf, 0, NULL);
-    if (lpMsgBuf) {
-	char *p;
-	rv = strdup(lpMsgBuf);
-	LocalFree(lpMsgBuf);
-	/* trim to the left */
-	if (rv)
-	    for (p = rv + strlen(rv) - 1; p >= rv; p--) {
-		if (isspace(*p))
-		    *p = '\0';
-		else
-		    break;
-	    }
+  FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+                FORMAT_MESSAGE_IGNORE_INSERTS, NULL, ms_err,
+                MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), /* Default language */
+                (LPTSTR) &lpMsgBuf, 0, NULL);
+  if (lpMsgBuf)
+    {
+      char *p;
+      rv = strdup(lpMsgBuf);
+      LocalFree(lpMsgBuf);
+      /* trim to the left */
+      if (rv)
+        for (p = rv + strlen(rv) - 1; p >= rv; p--)
+          {
+            if (isspace(*p))
+              *p = '\0';
+            else
+              break;
+          }
     }
-    return rv;
+  return rv;
 }
 
-static void err_put_ms_error(DWORD ms_err, int func, const char *file, int line)
+static void
+err_put_ms_error(DWORD ms_err, int func, const char *file, int line)
 {
-    static int init = 0;
-#   define ERR_MAP_SZ 16
-    static struct {
-	int err;
-	DWORD ms_err;	    /* I don't think we get more than 16 *different* errors */
-    } err_map[ERR_MAP_SZ];  /* in here, before we give up the whole thing...        */
-    int i;
+  static int init = 0;
+#define ERR_MAP_SZ 16
+  static struct {
+    int err;
+    DWORD ms_err;         /* I don't think we get more than 16 *different* errors */
+  } err_map[ERR_MAP_SZ];  /* in here, before we give up the whole thing...        */
+  int i;
 
-    if (ms_err == 0)
-	/* 0 is not an error */
-	return;
-    if (!init) {
-	ERR_load_strings(ERR_LIB_CRYPTOAPI, CRYPTOAPI_str_functs);
-	memset(&err_map, 0, sizeof(err_map));
-	init++;
+  if (ms_err == 0)
+    /* 0 is not an error */
+    return;
+  if (!init)
+    {
+      ERR_load_strings(ERR_LIB_CRYPTOAPI, CRYPTOAPI_str_functs);
+      memset(&err_map, 0, sizeof(err_map));
+      init++;
     }
-    /* since MS error codes are 32 bit, and the ones in the ERR_... system is
-     * only 12, we must have a mapping table between them.  */
-    for (i = 0; i < ERR_MAP_SZ; i++) {
-	if (err_map[i].ms_err == ms_err) {
-	    ERR_PUT_error(ERR_LIB_CRYPTOAPI, func, err_map[i].err, file, line);
-	    break;
-	} else if (err_map[i].ms_err == 0 ) {
-	    /* end of table, add new entry */
-	    ERR_STRING_DATA *esd = calloc(2, sizeof(*esd));
-	    if (esd == NULL)
-		break;
-	    err_map[i].ms_err = ms_err;
-	    err_map[i].err = esd->error = i + 100;
-	    esd->string = ms_error_text(ms_err);
-	    ERR_load_strings(ERR_LIB_CRYPTOAPI, esd);
-	    ERR_PUT_error(ERR_LIB_CRYPTOAPI, func, err_map[i].err, file, line);
-	    break;
-	}
+  /* since MS error codes are 32 bit, and the ones in the ERR_... system is
+   * only 12, we must have a mapping table between them.  */
+  for (i = 0; i < ERR_MAP_SZ; i++)
+    {
+      if (err_map[i].ms_err == ms_err)
+        {
+          ERR_PUT_error(ERR_LIB_CRYPTOAPI, func, err_map[i].err, file, line);
+          break;
+        }
+      else if (err_map[i].ms_err == 0 )
+        {
+          /* end of table, add new entry */
+          ERR_STRING_DATA *esd = calloc(2, sizeof(*esd));
+          if (esd == NULL)
+            break;
+          err_map[i].ms_err = ms_err;
+          err_map[i].err = esd->error = i + 100;
+          esd->string = ms_error_text(ms_err);
+          ERR_load_strings(ERR_LIB_CRYPTOAPI, esd);
+          ERR_PUT_error(ERR_LIB_CRYPTOAPI, func, err_map[i].err, file, line);
+          break;
+        }
     }
 }
 
 /* encrypt */
-static int rsa_pub_enc(int flen, const unsigned char *from, unsigned char *to, RSA *rsa, int padding)
+static int
+rsa_pub_enc(int flen, const unsigned char *from, unsigned char *to, RSA *rsa, int padding)
 {
-    /* I haven't been able to trigger this one, but I want to know if it happens... */
-    assert(0);
+  /* I haven't been able to trigger this one, but I want to know if it happens... */
+  assert(0);
 
-    return 0;
+  return 0;
 }
 
 /* verify arbitrary data */
-static int rsa_pub_dec(int flen, const unsigned char *from, unsigned char *to, RSA *rsa, int padding)
+static int
+rsa_pub_dec(int flen, const unsigned char *from, unsigned char *to, RSA *rsa, int padding)
 {
-    /* I haven't been able to trigger this one, but I want to know if it happens... */
-    assert(0);
+  /* I haven't been able to trigger this one, but I want to know if it happens... */
+  assert(0);
 
-    return 0;
+  return 0;
 }
 
 /* sign arbitrary data */
-static int rsa_priv_enc(int flen, const unsigned char *from, unsigned char *to, RSA *rsa, int padding)
+static int
+rsa_priv_enc(int flen, const unsigned char *from, unsigned char *to, RSA *rsa, int padding)
 {
-    CAPI_DATA *cd = (CAPI_DATA *) rsa->meth->app_data;
-    HCRYPTHASH hash;
-    DWORD hash_size, len, i;
-    unsigned char *buf;
+  CAPI_DATA *cd = (CAPI_DATA *) rsa->meth->app_data;
+  HCRYPTHASH hash;
+  DWORD hash_size, len, i;
+  unsigned char *buf;
 
-    if (cd == NULL) {
-	RSAerr(RSA_F_RSA_EAY_PRIVATE_ENCRYPT, ERR_R_PASSED_NULL_PARAMETER);
-	return 0;
+  if (cd == NULL)
+    {
+      RSAerr(RSA_F_RSA_EAY_PRIVATE_ENCRYPT, ERR_R_PASSED_NULL_PARAMETER);
+      return 0;
     }
-    if (padding != RSA_PKCS1_PADDING) {
-	/* AFAICS, CryptSignHash() *always* uses PKCS1 padding. */
-	RSAerr(RSA_F_RSA_EAY_PRIVATE_ENCRYPT, RSA_R_UNKNOWN_PADDING_TYPE);
-	return 0;
+  if (padding != RSA_PKCS1_PADDING)
+    {
+      /* AFAICS, CryptSignHash() *always* uses PKCS1 padding. */
+      RSAerr(RSA_F_RSA_EAY_PRIVATE_ENCRYPT, RSA_R_UNKNOWN_PADDING_TYPE);
+      return 0;
     }
-    /* Unfortunately, there is no "CryptSign()" function in CryptoAPI, that would
-     * be way to straightforward for M$, I guess... So we have to do it this
-     * tricky way instead, by creating a "Hash", and load the already-made hash
-     * from 'from' into it.  */
-    /* For now, we only support NID_md5_sha1 */
-    if (flen != SSL_SIG_LENGTH) {
-	RSAerr(RSA_F_RSA_EAY_PRIVATE_ENCRYPT, RSA_R_INVALID_MESSAGE_LENGTH);
-	return 0;
+  /* Unfortunately, there is no "CryptSign()" function in CryptoAPI, that would
+    * be way to straightforward for M$, I guess... So we have to do it this
+    * tricky way instead, by creating a "Hash", and load the already-made hash
+    * from 'from' into it.  */
+  /* For now, we only support NID_md5_sha1 */
+  if (flen != SSL_SIG_LENGTH)
+    {
+      RSAerr(RSA_F_RSA_EAY_PRIVATE_ENCRYPT, RSA_R_INVALID_MESSAGE_LENGTH);
+      return 0;
     }
-    if (!CryptCreateHash(cd->crypt_prov, CALG_SSL3_SHAMD5, 0, 0, &hash)) {
-	CRYPTOAPIerr(CRYPTOAPI_F_CRYPT_CREATE_HASH);
-	return 0;
+  if (!CryptCreateHash(cd->crypt_prov, CALG_SSL3_SHAMD5, 0, 0, &hash))
+    {
+      CRYPTOAPIerr(CRYPTOAPI_F_CRYPT_CREATE_HASH);
+      return 0;
     }
-    len = sizeof(hash_size);
-    if (!CryptGetHashParam(hash, HP_HASHSIZE, (BYTE *) &hash_size, &len, 0)) {
-	CRYPTOAPIerr(CRYPTOAPI_F_CRYPT_GET_HASH_PARAM);
-        CryptDestroyHash(hash);
-	return 0;
+  len = sizeof(hash_size);
+  if (!CryptGetHashParam(hash, HP_HASHSIZE, (BYTE *) &hash_size, &len, 0))
+    {
+      CRYPTOAPIerr(CRYPTOAPI_F_CRYPT_GET_HASH_PARAM);
+      CryptDestroyHash(hash);
+      return 0;
     }
-    if ((int) hash_size != flen) {
-	RSAerr(RSA_F_RSA_EAY_PRIVATE_ENCRYPT, RSA_R_INVALID_MESSAGE_LENGTH);
-        CryptDestroyHash(hash);
-	return 0;
+  if ((int) hash_size != flen)
+    {
+      RSAerr(RSA_F_RSA_EAY_PRIVATE_ENCRYPT, RSA_R_INVALID_MESSAGE_LENGTH);
+      CryptDestroyHash(hash);
+      return 0;
     }
-    if (!CryptSetHashParam(hash, HP_HASHVAL, (BYTE * ) from, 0)) {
-	CRYPTOAPIerr(CRYPTOAPI_F_CRYPT_SET_HASH_PARAM);
-        CryptDestroyHash(hash);
-	return 0;
+  if (!CryptSetHashParam(hash, HP_HASHVAL, (BYTE * ) from, 0))
+    {
+      CRYPTOAPIerr(CRYPTOAPI_F_CRYPT_SET_HASH_PARAM);
+      CryptDestroyHash(hash);
+      return 0;
     }
 
-    len = RSA_size(rsa);
-    buf = malloc(len);
-    if (buf == NULL) {
-	RSAerr(RSA_F_RSA_EAY_PRIVATE_ENCRYPT, ERR_R_MALLOC_FAILURE);
-        CryptDestroyHash(hash);
-	return 0;
+  len = RSA_size(rsa);
+  buf = malloc(len);
+  if (buf == NULL)
+    {
+      RSAerr(RSA_F_RSA_EAY_PRIVATE_ENCRYPT, ERR_R_MALLOC_FAILURE);
+      CryptDestroyHash(hash);
+      return 0;
     }
-    if (!CryptSignHash(hash, cd->key_spec, NULL, 0, buf, &len)) {
-	CRYPTOAPIerr(CRYPTOAPI_F_CRYPT_SIGN_HASH);
-        CryptDestroyHash(hash);
-        free(buf);
-	return 0;
+  if (!CryptSignHash(hash, cd->key_spec, NULL, 0, buf, &len))
+    {
+      CRYPTOAPIerr(CRYPTOAPI_F_CRYPT_SIGN_HASH);
+      CryptDestroyHash(hash);
+      free(buf);
+      return 0;
     }
-    /* and now, we have to reverse the byte-order in the result from CryptSignHash()... */
-    for (i = 0; i < len; i++)
-	to[i] = buf[len - i - 1];
-    free(buf);
+  /* and now, we have to reverse the byte-order in the result from CryptSignHash()... */
+  for (i = 0; i < len; i++)
+    to[i] = buf[len - i - 1];
+  free(buf);
 
-    CryptDestroyHash(hash);
-    return len;
+  CryptDestroyHash(hash);
+  return len;
 }
 
 /* decrypt */
-static int rsa_priv_dec(int flen, const unsigned char *from, unsigned char *to, RSA *rsa, int padding)
+static int
+rsa_priv_dec(int flen, const unsigned char *from, unsigned char *to, RSA *rsa, int padding)
 {
-    /* I haven't been able to trigger this one, but I want to know if it happens... */
-    assert(0);
+  /* I haven't been able to trigger this one, but I want to know if it happens... */
+  assert(0);
 
-    return 0;
+  return 0;
 }
 
 /* called at RSA_new */
-static int init(RSA *rsa)
+static int
+init(RSA *rsa)
 {
-
-    return 0;
+  return 0;
 }
 
 /* called at RSA_free */
-static int finish(RSA *rsa)
+static int
+finish(RSA *rsa)
 {
-    CAPI_DATA *cd = (CAPI_DATA *) rsa->meth->app_data;
+  CAPI_DATA *cd = (CAPI_DATA *) rsa->meth->app_data;
 
-    if (cd == NULL)
-	return 0;
-    if (cd->crypt_prov && cd->free_crypt_prov)
-	CryptReleaseContext(cd->crypt_prov, 0);
-    if (cd->cert_context)
-	CertFreeCertificateContext(cd->cert_context);
-    free(rsa->meth->app_data);
-    free((char *) rsa->meth);
-    rsa->meth = NULL;
-    return 1;
-}
-
-static const CERT_CONTEXT *find_certificate_in_store(const char *cert_prop, HCERTSTORE cert_store)
-{
-    /* Find, and use, the desired certificate from the store. The
-     * 'cert_prop' certificate search string can look like this:
-     * SUBJ:<certificate substring to match>
-     * THUMB:<certificate thumbprint hex value>, e.g.
-     *     THUMB:f6 49 24 41 01 b4 fb 44 0c ce f4 36 ae d0 c4 c9 df 7a b6 28
-     */
-    const CERT_CONTEXT *rv = NULL;
-
-    if (!strncmp(cert_prop, "SUBJ:", 5)) {
-	/* skip the tag */
-	cert_prop += 5;
-	rv = CertFindCertificateInStore(cert_store, X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
-		0, CERT_FIND_SUBJECT_STR_A, cert_prop, NULL);
-
-    } else if (!strncmp(cert_prop, "THUMB:", 6)) {
-	unsigned char hash[255];
-	char *p;
-	int i, x = 0;
-	CRYPT_HASH_BLOB blob;
-
-	/* skip the tag */
-	cert_prop += 6;
-	for (p = (char *) cert_prop, i = 0; *p && i < sizeof(hash); i++) {
-	    if (*p >= '0' && *p <= '9')
-		x = (*p - '0') << 4;
-	    else if (*p >= 'A' && *p <= 'F')
-		x = (*p - 'A' + 10) << 4;
-	    else if (*p >= 'a' && *p <= 'f')
-		x = (*p - 'a' + 10) << 4;
-	    if (!*++p)	/* unexpected end of string */
-		break;
-	    if (*p >= '0' && *p <= '9')
-		x += *p - '0';
-	    else if (*p >= 'A' && *p <= 'F')
-		x += *p - 'A' + 10;
-	    else if (*p >= 'a' && *p <= 'f')
-		x += *p - 'a' + 10;
-	    hash[i] = x;
-	    /* skip any space(s) between hex numbers */
-	    for (p++; *p && *p == ' '; p++);
-	}
-	blob.cbData = i;
-	blob.pbData = (unsigned char *) &hash;
-	rv = CertFindCertificateInStore(cert_store, X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
-		0, CERT_FIND_HASH, &blob, NULL);
-
-    }
-
-    return rv;
-}
-
-int SSL_CTX_use_CryptoAPI_certificate(SSL_CTX *ssl_ctx, const char *cert_prop)
-{
-    HCERTSTORE cs;
-    X509 *cert = NULL;
-    RSA *rsa = NULL, *pub_rsa;
-    CAPI_DATA *cd = calloc(1, sizeof(*cd));
-    RSA_METHOD *my_rsa_method = calloc(1, sizeof(*my_rsa_method));
-
-    if (cd == NULL || my_rsa_method == NULL) {
-	SSLerr(SSL_F_SSL_CTX_USE_CERTIFICATE_FILE, ERR_R_MALLOC_FAILURE);
-	goto err;
-    }
-    /* search CURRENT_USER first, then LOCAL_MACHINE */
-    cs = CertOpenStore((LPCSTR) CERT_STORE_PROV_SYSTEM, 0, 0, CERT_SYSTEM_STORE_CURRENT_USER |
-		       CERT_STORE_OPEN_EXISTING_FLAG | CERT_STORE_READONLY_FLAG, L"MY");
-    if (cs == NULL) {
-	CRYPTOAPIerr(CRYPTOAPI_F_CERT_OPEN_SYSTEM_STORE);
-	goto err;
-    }
-    cd->cert_context = find_certificate_in_store(cert_prop, cs);
-    CertCloseStore(cs, 0);
-    if (!cd->cert_context) {
-	cs = CertOpenStore((LPCSTR) CERT_STORE_PROV_SYSTEM, 0, 0, CERT_SYSTEM_STORE_LOCAL_MACHINE |
-			   CERT_STORE_OPEN_EXISTING_FLAG | CERT_STORE_READONLY_FLAG, L"MY");
-	if (cs == NULL) {
-	    CRYPTOAPIerr(CRYPTOAPI_F_CERT_OPEN_SYSTEM_STORE);
-	    goto err;
-	}
-	cd->cert_context = find_certificate_in_store(cert_prop, cs);
-	CertCloseStore(cs, 0);
-	if (cd->cert_context == NULL) {
-	    CRYPTOAPIerr(CRYPTOAPI_F_CERT_FIND_CERTIFICATE_IN_STORE);
-	    goto err;
-	}
-    }
-
-    /* cert_context->pbCertEncoded is the cert X509 DER encoded. */
-    cert = d2i_X509(NULL, (const unsigned char **) &cd->cert_context->pbCertEncoded,
-		    cd->cert_context->cbCertEncoded);
-    if (cert == NULL) {
-	SSLerr(SSL_F_SSL_CTX_USE_CERTIFICATE_FILE, ERR_R_ASN1_LIB);
-	goto err;
-    }
-
-    /* set up stuff to use the private key */
-    if (!CryptAcquireCertificatePrivateKey(cd->cert_context, CRYPT_ACQUIRE_COMPARE_KEY_FLAG,
-	    NULL, &cd->crypt_prov, &cd->key_spec, &cd->free_crypt_prov)) {
-	/* if we don't have a smart card reader here, and we try to access a
-	 * smart card certificate, we get:
-	 * "Error 1223: The operation was canceled by the user." */
-	CRYPTOAPIerr(CRYPTOAPI_F_CRYPT_ACQUIRE_CERTIFICATE_PRIVATE_KEY);
-	goto err;
-    }
-    /* here we don't need to do CryptGetUserKey() or anything; all necessary key
-     * info is in cd->cert_context, and then, in cd->crypt_prov.  */
-
-    my_rsa_method->name = "Microsoft CryptoAPI RSA Method";
-    my_rsa_method->rsa_pub_enc = rsa_pub_enc;
-    my_rsa_method->rsa_pub_dec = rsa_pub_dec;
-    my_rsa_method->rsa_priv_enc = rsa_priv_enc;
-    my_rsa_method->rsa_priv_dec = rsa_priv_dec;
-    /* my_rsa_method->init = init; */
-    my_rsa_method->finish = finish;
-    my_rsa_method->flags = RSA_METHOD_FLAG_NO_CHECK;
-    my_rsa_method->app_data = (char *) cd;
-
-    rsa = RSA_new();
-    if (rsa == NULL) {
-	SSLerr(SSL_F_SSL_CTX_USE_CERTIFICATE_FILE, ERR_R_MALLOC_FAILURE);
-	goto err;
-    }
-
-    /* cert->cert_info->key->pkey is NULL until we call SSL_CTX_use_certificate(),
-     * so we do it here then...  */
-    if (!SSL_CTX_use_certificate(ssl_ctx, cert))
-	goto err;
-    /* the public key */
-    pub_rsa = cert->cert_info->key->pkey->pkey.rsa;
-    /* SSL_CTX_use_certificate() increased the reference count in 'cert', so
-     * we decrease it here with X509_free(), or it will never be cleaned up. */
-    X509_free(cert);
-    cert = NULL;
-
-    /* I'm not sure about what we have to fill in in the RSA, trying out stuff... */
-    /* rsa->n indicates the key size */
-    rsa->n = BN_dup(pub_rsa->n);
-    rsa->flags |= RSA_FLAG_EXT_PKEY;
-    if (!RSA_set_method(rsa, my_rsa_method))
-	goto err;
-
-    if (!SSL_CTX_use_RSAPrivateKey(ssl_ctx, rsa))
-	goto err;
-    /* SSL_CTX_use_RSAPrivateKey() increased the reference count in 'rsa', so
-     * we decrease it here with RSA_free(), or it will never be cleaned up. */
-    RSA_free(rsa);
-    return 1;
-
-  err:
-    if (cert)
-	X509_free(cert);
-    if (rsa)
-	RSA_free(rsa);
-    else {
-	if (my_rsa_method)
-	    free(my_rsa_method);
-	if (cd) {
-	    if (cd->free_crypt_prov && cd->crypt_prov)
-		CryptReleaseContext(cd->crypt_prov, 0);
-	    if (cd->cert_context)
-		CertFreeCertificateContext(cd->cert_context);
-	    free(cd);
-	}
-    }
+  if (cd == NULL)
     return 0;
+  if (cd->crypt_prov && cd->free_crypt_prov)
+    CryptReleaseContext(cd->crypt_prov, 0);
+  if (cd->cert_context)
+    CertFreeCertificateContext(cd->cert_context);
+  free(rsa->meth->app_data);
+  free((char *) rsa->meth);
+  rsa->meth = NULL;
+  return 1;
+}
+
+static const CERT_CONTEXT *
+find_certificate_in_store(const char *cert_prop, HCERTSTORE cert_store)
+{
+  /* Find, and use, the desired certificate from the store. The
+    * 'cert_prop' certificate search string can look like this:
+    * SUBJ:<certificate substring to match>
+    * THUMB:<certificate thumbprint hex value>, e.g.
+    *     THUMB:f6 49 24 41 01 b4 fb 44 0c ce f4 36 ae d0 c4 c9 df 7a b6 28
+    */
+  const CERT_CONTEXT *rv = NULL;
+
+  if (!strncmp(cert_prop, "SUBJ:", strlen("SUBJ:")))
+    {
+      /* skip the tag */
+      cert_prop += strlen("SUBJ:");
+      rv = CertFindCertificateInStore(cert_store,
+                                      X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
+                                      0, CERT_FIND_SUBJECT_STR_A, cert_prop,
+                                      NULL);
+    }
+  else if (!strncmp(cert_prop, "THUMB:", strlen("THUMB:")))
+    {
+      unsigned char hash[255];
+      char *p;
+      int i, x = 0;
+      CRYPT_HASH_BLOB blob;
+
+      /* skip the tag */
+      cert_prop += strlen("THUMB:");
+      for (p = (char *) cert_prop, i = 0; *p && i < sizeof(hash); i++)
+        {
+          if (*p >= '0' && *p <= '9')
+            x = (*p - '0') << 4;
+          else if (*p >= 'A' && *p <= 'F')
+            x = (*p - 'A' + 10) << 4;
+          else if (*p >= 'a' && *p <= 'f')
+            x = (*p - 'a' + 10) << 4;
+          if (!*++p)	/* unexpected end of string */
+            break;
+          if (*p >= '0' && *p <= '9')
+            x += *p - '0';
+          else if (*p >= 'A' && *p <= 'F')
+            x += *p - 'A' + 10;
+          else if (*p >= 'a' && *p <= 'f')
+            x += *p - 'a' + 10;
+          hash[i] = x;
+          /* skip any space(s) between hex numbers */
+          for (p++; *p && *p == ' '; p++);
+        }
+      blob.cbData = i;
+      blob.pbData = (unsigned char *) &hash;
+      rv = CertFindCertificateInStore(cert_store,
+                                      X509_ASN_ENCODING | PKCS_7_ASN_ENCODING,
+                                      0, CERT_FIND_HASH, &blob, NULL);
+    }
+
+  return rv;
+}
+
+int
+SSL_CTX_use_CryptoAPI_certificate(SSL_CTX *ssl_ctx, const char *cert_prop)
+{
+  HCERTSTORE cs;
+  X509 *cert = NULL;
+  RSA *rsa = NULL, *pub_rsa;
+  CAPI_DATA *cd = calloc(1, sizeof(*cd));
+  RSA_METHOD *my_rsa_method = calloc(1, sizeof(*my_rsa_method));
+
+  if (cd == NULL || my_rsa_method == NULL)
+    {
+      SSLerr(SSL_F_SSL_CTX_USE_CERTIFICATE_FILE, ERR_R_MALLOC_FAILURE);
+      goto err;
+    }
+  /* search CURRENT_USER first, then LOCAL_MACHINE */
+  cs = CertOpenStore((LPCSTR) CERT_STORE_PROV_SYSTEM, 0, 0,
+                     CERT_SYSTEM_STORE_CURRENT_USER |
+                     CERT_STORE_OPEN_EXISTING_FLAG | CERT_STORE_READONLY_FLAG,
+                     L"MY");
+  if (cs == NULL)
+    {
+      CRYPTOAPIerr(CRYPTOAPI_F_CERT_OPEN_SYSTEM_STORE);
+      goto err;
+    }
+  cd->cert_context = find_certificate_in_store(cert_prop, cs);
+  CertCloseStore(cs, 0);
+  if (!cd->cert_context)
+    {
+      cs = CertOpenStore((LPCSTR) CERT_STORE_PROV_SYSTEM, 0, 0,
+                         CERT_SYSTEM_STORE_LOCAL_MACHINE |
+                         CERT_STORE_OPEN_EXISTING_FLAG |
+                         CERT_STORE_READONLY_FLAG, L"MY");
+      if (cs == NULL)
+        {
+          CRYPTOAPIerr(CRYPTOAPI_F_CERT_OPEN_SYSTEM_STORE);
+          goto err;
+        }
+      cd->cert_context = find_certificate_in_store(cert_prop, cs);
+      CertCloseStore(cs, 0);
+      if (cd->cert_context == NULL)
+        {
+          CRYPTOAPIerr(CRYPTOAPI_F_CERT_FIND_CERTIFICATE_IN_STORE);
+          goto err;
+        }
+    }
+
+  /* cert_context->pbCertEncoded is the cert X509 DER encoded. */
+  cert = d2i_X509(NULL,
+                  (const unsigned char **) &cd->cert_context->pbCertEncoded,
+                  cd->cert_context->cbCertEncoded);
+  if (cert == NULL)
+    {
+      SSLerr(SSL_F_SSL_CTX_USE_CERTIFICATE_FILE, ERR_R_ASN1_LIB);
+      goto err;
+    }
+
+  /* set up stuff to use the private key */
+  if (!CryptAcquireCertificatePrivateKey(cd->cert_context,
+                                         CRYPT_ACQUIRE_COMPARE_KEY_FLAG,
+                                         NULL, &cd->crypt_prov, &cd->key_spec,
+                                         &cd->free_crypt_prov))
+    {
+      /* if we don't have a smart card reader here, and we try to access a
+        * smart card certificate, we get:
+        * "Error 1223: The operation was canceled by the user." */
+      CRYPTOAPIerr(CRYPTOAPI_F_CRYPT_ACQUIRE_CERTIFICATE_PRIVATE_KEY);
+      goto err;
+    }
+  /* here we don't need to do CryptGetUserKey() or anything; all necessary key
+   * info is in cd->cert_context, and then, in cd->crypt_prov.  */
+
+  my_rsa_method->name = "Microsoft CryptoAPI RSA Method";
+  my_rsa_method->rsa_pub_enc = rsa_pub_enc;
+  my_rsa_method->rsa_pub_dec = rsa_pub_dec;
+  my_rsa_method->rsa_priv_enc = rsa_priv_enc;
+  my_rsa_method->rsa_priv_dec = rsa_priv_dec;
+  /* my_rsa_method->init = init; */
+  my_rsa_method->finish = finish;
+  my_rsa_method->flags = RSA_METHOD_FLAG_NO_CHECK;
+  my_rsa_method->app_data = (char *) cd;
+
+  rsa = RSA_new();
+  if (rsa == NULL)
+    {
+      SSLerr(SSL_F_SSL_CTX_USE_CERTIFICATE_FILE, ERR_R_MALLOC_FAILURE);
+      goto err;
+    }
+
+  /* cert->cert_info->key->pkey is NULL until we call SSL_CTX_use_certificate(),
+   * so we do it here then...  */
+  if (!SSL_CTX_use_certificate(ssl_ctx, cert))
+    goto err;
+  /* the public key */
+  pub_rsa = cert->cert_info->key->pkey->pkey.rsa;
+  /* SSL_CTX_use_certificate() increased the reference count in 'cert', so
+   * we decrease it here with X509_free(), or it will never be cleaned up. */
+  X509_free(cert);
+  cert = NULL;
+
+  /* I'm not sure about what we have to fill in in the RSA, trying out stuff... */
+  /* rsa->n indicates the key size */
+  rsa->n = BN_dup(pub_rsa->n);
+  rsa->flags |= RSA_FLAG_EXT_PKEY;
+  if (!RSA_set_method(rsa, my_rsa_method))
+    goto err;
+
+  if (!SSL_CTX_use_RSAPrivateKey(ssl_ctx, rsa))
+    goto err;
+  /* SSL_CTX_use_RSAPrivateKey() increased the reference count in 'rsa', so
+    * we decrease it here with RSA_free(), or it will never be cleaned up. */
+  RSA_free(rsa);
+  return 1;
+
+err:
+  if (cert)
+    X509_free(cert);
+  if (rsa)
+    RSA_free(rsa);
+  else
+    {
+      if (my_rsa_method)
+        free(my_rsa_method);
+      if (cd)
+        {
+          if (cd->free_crypt_prov && cd->crypt_prov)
+            CryptReleaseContext(cd->crypt_prov, 0);
+          if (cd->cert_context)
+            CertFreeCertificateContext(cd->cert_context);
+          free(cd);
+        }
+    }
+  return 0;
 }
 
 #else
 #ifdef _MSC_VER  /* Dummy function needed to avoid empty file compiler warning in Microsoft VC */
 static void dummy (void) {}
 #endif
-#endif				/* WIN32 */
+#endif				/* ENABLE_CRYPTOAPI */

--- a/src/openvpn/keychain.c
+++ b/src/openvpn/keychain.c
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2004 Peter 'Luna' Runestig <peter@runestig.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modifi-
+ * cation, are permitted provided that the following conditions are met:
+ *
+ *   o  Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *
+ *   o  Redistributions in binary form must reproduce the above copyright no-
+ *      tice, this list of conditions and the following disclaimer in the do-
+ *      cumentation and/or other materials provided with the distribution.
+ *
+ *   o  The names of the contributors may not be used to endorse or promote
+ *      products derived from this software without specific prior written
+ *      permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LI-
+ * ABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUEN-
+ * TIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEV-
+ * ER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABI-
+ * LITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This code has been modified from the original version by Brian Raderman
+ * <brian@irregularexpression.org>.  It was changed to work with the Mac OS X
+ * Keychain services instead of the Microsoft Crypto API, which was its original
+ * intent.
+ *
+ * This was ported to OpenVPN 2.3.2 code style and API by Radu - Eosif
+ * Mihailescu <rmihailescu@google.com>
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "syshead.h"
+
+#ifdef ENABLE_KEYCHAIN
+
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#include <stdio.h>
+#include <stddef.h>
+#include <ctype.h>
+#include <assert.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
+#include "buffer.h"
+#include "macosx.h"
+
+/* try to funnel any Keychain/CSSM error messages to OpenSSL ERR_... */
+#define ERR_LIB_KEYCHAIN (ERR_LIB_USER + 70)
+#define KeychainErr(f)   err_put_apple_error((f), __FILE__, __LINE__)
+#define KEYCHAIN_F_FIND_IDENTITY        	    101
+#define KEYCHAIN_F_CREATE_CERT_DATA_FROM_STRING     102
+#define KEYCHAIN_F_SIGN_DATA			    103
+
+static ERR_STRING_DATA KEYCHAIN_str_functs[] =	{
+  { ERR_PACK(ERR_LIB_KEYCHAIN, 0, 0),                        "Mac OS X Keychain"},
+  { ERR_PACK(0, KEYCHAIN_F_FIND_IDENTITY, 0),                "findIdentity" },
+  { ERR_PACK(0, KEYCHAIN_F_CREATE_CERT_DATA_FROM_STRING, 0), "createCertDataFromString" },
+  { ERR_PACK(0, KEYCHAIN_F_SIGN_DATA, 0),                    "signData" },
+  { 0, NULL }
+};
+
+typedef struct _AppData {
+  SecIdentityRef identity;
+  struct gc_arena arena;
+} AppData;
+
+static void
+err_put_apple_error(int func, const char *file, int line)
+{
+  static int init = 0;
+
+  if (!init)
+    {
+      ERR_load_strings(ERR_LIB_KEYCHAIN, KEYCHAIN_str_functs);
+      ERR_STRING_DATA *esd = calloc(4, sizeof(ERR_STRING_DATA));
+      if (esd)
+        {
+          esd[0].error = 101;
+          esd[0].string = "Unable to find identity in Keychain (certificate + private key)";
+
+          esd[1].error = 102;
+          esd[1].string = "Unable to parse certificate description string";
+
+          esd[2].error = 103;
+          esd[2].string = "Unable to sign data with private key";
+
+          ERR_load_strings(ERR_LIB_KEYCHAIN, esd);
+        }
+      init++;
+    }
+  ERR_PUT_error(ERR_LIB_KEYCHAIN, func, 0, file, line);
+}
+
+/* encrypt */
+static int
+rsa_pub_enc(int flen, const unsigned char *from, unsigned char *to, RSA *rsa, int padding)
+{
+  /* I haven't been able to trigger this one, but I want to know if it happens... */
+  assert(0);
+
+  return 0;
+}
+
+/* verify arbitrary data */
+static int
+rsa_pub_dec(int flen, const unsigned char *from, unsigned char *to, RSA *rsa, int padding)
+{
+  /* I haven't been able to trigger this one, but I want to know if it happens... */
+  assert(0);
+
+  return 0;
+}
+
+/* sign arbitrary data */
+static int
+rsa_priv_enc(int flen, const unsigned char *from, unsigned char *to, RSA *rsa, int padding)
+{
+  AppData *pData = (AppData *) rsa->meth->app_data;
+
+  if (pData == NULL || pData->identity == NULL)
+    {
+      RSAerr(RSA_F_RSA_EAY_PRIVATE_ENCRYPT, ERR_R_PASSED_NULL_PARAMETER);
+      return 0;
+    }
+  if (padding != RSA_PKCS1_PADDING)
+    {
+      RSAerr(RSA_F_RSA_EAY_PRIVATE_ENCRYPT, RSA_R_UNKNOWN_PADDING_TYPE);
+      return 0;
+    }
+
+  cryptoSignData(pData->identity, from, flen, to);
+
+  return RSA_size(rsa);
+}
+
+/* decrypt */
+static int
+rsa_priv_dec(int flen, const unsigned char *from, unsigned char *to, RSA *rsa, int padding)
+{
+  /* I haven't been able to trigger this one, but I want to know if it happens... */
+  assert(0);
+
+  return 0;
+}
+
+/* called at RSA_new */
+static int
+init(RSA *rsa)
+{
+  return 0;
+}
+
+/* called at RSA_free */
+static int
+finish(RSA *rsa)
+{
+  AppData *pData = (AppData *) rsa->meth->app_data;
+
+  if (pData == NULL || pData->identity == NULL)
+    return 0;
+  CFRelease(pData->identity);
+  gc_free(&(pData->arena));
+  rsa->meth = NULL;
+  return 1;
+}
+
+int SSL_CTX_use_Keychain_certificate(SSL_CTX *ssl_ctx, const char *cert_prop)
+{
+  X509 *cert = NULL;
+  RSA *rsa = NULL, *pub_rsa;
+  SecIdentityRef identity = NULL;
+  size_t cert_len;
+  struct gc_arena arena = gc_new();
+  AppData *pData = (AppData*)gc_malloc(sizeof(AppData), false, &arena);
+  RSA_METHOD *my_rsa_method = (RSA_METHOD*)gc_malloc(sizeof(RSA_METHOD), true, &arena);
+
+  if (pData == NULL || my_rsa_method == NULL)
+    {
+      SSLerr(SSL_F_SSL_CTX_USE_CERTIFICATE_FILE, ERR_R_MALLOC_FAILURE);
+      goto err;
+    }
+  pData->arena = arena;
+
+  identity = findIdentityByString(cert_prop);
+
+  if (!identity)
+    {
+      KeychainErr(KEYCHAIN_F_FIND_IDENTITY);
+      goto err;
+    }
+  pData->identity = identity;
+
+  extractCertificateFromIdentity(identity, &cert, &cert_len);
+
+  /* cert is the cert X509 DER encoded. */
+  cert = d2i_X509(NULL, (const unsigned char **) &cert, cert_len);
+  if (cert == NULL)
+    {
+      SSLerr(SSL_F_SSL_CTX_USE_CERTIFICATE_FILE, ERR_R_ASN1_LIB);
+      goto err;
+    }
+
+  my_rsa_method->name = "Mac OS X Keychain RSA Method";
+  my_rsa_method->rsa_pub_enc = rsa_pub_enc;
+  my_rsa_method->rsa_pub_dec = rsa_pub_dec;
+  my_rsa_method->rsa_priv_enc = rsa_priv_enc;
+  my_rsa_method->rsa_priv_dec = rsa_priv_dec;
+  /* my_rsa_method->init = init; */
+  my_rsa_method->finish = finish;
+  my_rsa_method->flags = RSA_METHOD_FLAG_NO_CHECK;
+  my_rsa_method->app_data = (char *) pData;
+
+  rsa = RSA_new();
+  if (rsa == NULL) {
+    SSLerr(SSL_F_SSL_CTX_USE_CERTIFICATE_FILE, ERR_R_MALLOC_FAILURE);
+    goto err;
+  }
+
+  /* cert->cert_info->key->pkey is NULL until we call SSL_CTX_use_certificate(),
+   * so we do it here then...  */
+  if (!SSL_CTX_use_certificate(ssl_ctx, cert))
+    goto err;
+  /* the public key */
+  pub_rsa = cert->cert_info->key->pkey->pkey.rsa;
+  /* SSL_CTX_use_certificate() increased the reference count in 'cert', so
+    * we decrease it here with X509_free(), or it will never be cleaned up. */
+  X509_free(cert);
+  cert = NULL;
+
+  /* I'm not sure about what we have to fill in in the RSA, trying out stuff... */
+  /* rsa->n indicates the key size */
+  rsa->n = BN_dup(pub_rsa->n);
+  rsa->flags |= RSA_FLAG_EXT_PKEY;
+  if (!RSA_set_method(rsa, my_rsa_method))
+    goto err;
+
+  if (!SSL_CTX_use_RSAPrivateKey(ssl_ctx, rsa))
+    goto err;
+
+  /* SSL_CTX_use_RSAPrivateKey() increased the reference count in 'rsa', so
+    * we decrease it here with RSA_free(), or it will never be cleaned up. */
+  RSA_free(rsa);
+  return 1;
+
+  err:
+    if (cert)
+      X509_free(cert);
+    if (rsa)
+      RSA_free(rsa);
+    else
+      if (identity)
+        CFRelease(identity);
+
+  gc_free(&arena);
+
+  return 0;
+}
+
+#endif  /*  ENABLE_KEYCHAIN */

--- a/src/openvpn/keychain.h
+++ b/src/openvpn/keychain.h
@@ -1,0 +1,7 @@
+#ifndef _KEYCHAIN_H_
+#define _KEYCHAIN_H_
+
+int SSL_CTX_use_Keychain_certificate(SSL_CTX *ssl_ctx, const char *cert_prop);
+
+
+#endif /* !_KEYCHAIN_H_ */

--- a/src/openvpn/macosx.c
+++ b/src/openvpn/macosx.c
@@ -1,0 +1,748 @@
+/*
+ *  OpenVPN -- An application to securely tunnel IP networks
+ *             over a single UDP port, with support for SSL/TLS-based
+ *             session authentication and key exchange,
+ *             packet encryption, packet authentication, and
+ *             packet compression.
+ *
+ *  Copyright (C) 2010 Brian Raderman <brian@irregularexpression.org>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2
+ *  as published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program (see the file COPYING included with this
+ *  distribution); if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ *  This is a concatenation of code originally in cert_data.c and crypto_osx.c,
+ *  both by Brian Raderman <brian@irregularexpression.org> done by
+ *  Radu - Eosif Mihailescu <rmihailescu@google.com>
+ */
+
+/*
+ * Mac OS X-specific OpenVPN code.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "syshead.h"
+
+#ifdef MACOSX
+
+#include <CommonCrypto/CommonDigest.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
+#include <stdbool.h>
+#include "buffer.h"
+#include "macosx.h"
+
+CFStringRef kCertDataSubjectName = CFSTR("subject"),
+    kCertDataIssuerName = CFSTR("issuer"), kCertDataSha1Name = CFSTR("SHA1"),
+    kCertDataMd5Name = CFSTR("MD5"), kCertNameFwdSlash = CFSTR("/"),
+    kCertNameEquals = CFSTR("="),
+    CFStringRef kCertNameOrganization = CFSTR("o"),
+    kCertNameOrganizationalUnit = CFSTR("ou"), kCertNameCountry = CFSTR("c"),
+    kCertNameLocality = CFSTR("l"), kCertNameState = CFSTR("st"),
+    kCertNameCommonName = CFSTR("cn"), kCertNameEmail = CFSTR("e"),
+    kCertNameDomainComponent = CFSTR("dc"), kStringSpace = CFSTR(" "),
+    kStringEmpty = CFSTR("");
+
+typedef struct
+{
+    CFArrayRef countryName, organization, organizationalUnit, commonName,
+        description, emailAddress, stateName, localityName, distinguishedName,
+        domainComponent;
+} CertName, *CertNameRef;
+
+typedef struct
+{
+    CFStringRef name, value;
+} DescData, *DescDataRef;
+
+typedef struct
+{
+    CFArrayRef subject;
+    CFArrayRef issuer;
+    CFStringRef md5, sha1;
+} CertData, *CertDataRef;
+
+static struct gc_arena g_gc;
+
+static void initCertData()
+{
+    g_gc = gc_new();
+}
+
+static void freeCertData()
+{
+    gc_free(&g_gc);
+}
+
+static void appendHexChar(CFMutableStringRef str, unsigned char halfByte)
+{
+    if (halfByte < 10)
+        CFStringAppendFormat (str, NULL, CFSTR("%d"), halfByte);
+    else switch(halfByte)
+    {
+        case 10:
+            CFStringAppendCString(str, "A", kCFStringEncodingUTF8);
+            break;
+        case 11:
+            CFStringAppendCString(str, "B", kCFStringEncodingUTF8);
+            break;
+        case 12:
+            CFStringAppendCString(str, "C", kCFStringEncodingUTF8);
+            break;
+        case 13:
+            CFStringAppendCString(str, "D", kCFStringEncodingUTF8);
+            break;
+        case 14:
+            CFStringAppendCString(str, "E", kCFStringEncodingUTF8);
+            break;
+        case 15:
+            CFStringAppendCString(str, "F", kCFStringEncodingUTF8);
+            break;
+    }
+}
+
+static CFStringRef createHexString(unsigned char *pData, int length)
+{
+    unsigned char byte, low, high;
+    int i;
+    CFMutableStringRef str = CFStringCreateMutable(NULL, 0);
+
+    for(i = 0;i < length;i++)
+    {
+        byte = pData[i];
+        low = byte & 0x0F;
+        high = (byte >> 4);
+
+        appendHexChar(str, high);
+        appendHexChar(str, low);
+
+        if (i != (length - 1))
+            CFStringAppendCString(str, " ", kCFStringEncodingUTF8);
+    }
+
+    return str;
+}
+
+static CertNameRef createCertName()
+{
+    CertNameRef pCertName = (CertNameRef)gc_malloc(sizeof(CertName), false, &g_gc);
+
+    pCertName->countryName = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+    pCertName->organization =  CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+    pCertName->organizationalUnit = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+    pCertName->commonName = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+    pCertName->description = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+    pCertName->emailAddress = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+    pCertName->stateName = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+    pCertName->localityName = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+    pCertName->distinguishedName = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+    pCertName->domainComponent = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+
+    return pCertName;
+}
+
+static void destroyCertName(CertNameRef pCertName)
+{
+    if (!pCertName)
+        return;
+
+    CFRelease(pCertName->countryName);
+    CFRelease(pCertName->organization);
+    CFRelease(pCertName->organizationalUnit);
+    CFRelease(pCertName->commonName);
+    CFRelease(pCertName->description);
+    CFRelease(pCertName->emailAddress);
+    CFRelease(pCertName->stateName);
+    CFRelease(pCertName->localityName);
+    CFRelease(pCertName->distinguishedName);
+    CFRelease(pCertName->domainComponent);
+}
+
+
+static CertNameRef dataToName(CSSM_DATA_PTR pData)
+{
+    CSSM_X509_NAME_PTR pName = (CSSM_X509_NAME_PTR)pData->Data;
+    CertNameRef pCertName = createCertName();
+    int i, j;
+
+    for(i = 0;i < pName->numberOfRDNs;i++)
+    {
+        CSSM_X509_RDN rdn = pName->RelativeDistinguishedName[i];
+
+        for(j = 0;j < rdn.numberOfPairs;j++)
+        {
+            CSSM_X509_TYPE_VALUE_PAIR nvp = rdn.AttributeTypeAndValue[j];
+            CFStringRef str = CFStringCreateWithBytes (NULL, nvp.value.Data, nvp.value.Length, kCFStringEncodingUTF8, false);
+
+            if (memcmp(nvp.type.Data, CSSMOID_CountryName.Data, CSSMOID_CountryName.Length) == 0)
+                    CFArrayAppendValue((CFMutableArrayRef)pCertName->countryName, str);
+            else if (memcmp(nvp.type.Data, CSSMOID_OrganizationName.Data, CSSMOID_OrganizationName.Length) == 0)
+                    CFArrayAppendValue((CFMutableArrayRef)pCertName->organization, str);
+            else if (memcmp(nvp.type.Data, CSSMOID_OrganizationalUnitName.Data, CSSMOID_OrganizationalUnitName.Length) == 0)
+                    CFArrayAppendValue((CFMutableArrayRef)pCertName->organizationalUnit, str);
+            else if (memcmp(nvp.type.Data, CSSMOID_CommonName.Data, CSSMOID_CommonName.Length) == 0)
+                    CFArrayAppendValue((CFMutableArrayRef)pCertName->commonName, str);
+            else if (memcmp(nvp.type.Data, CSSMOID_Description.Data, CSSMOID_Description.Length) == 0)
+                    CFArrayAppendValue((CFMutableArrayRef)pCertName->description, str);
+            else if (memcmp(nvp.type.Data, CSSMOID_EmailAddress.Data, CSSMOID_EmailAddress.Length) == 0)
+                    CFArrayAppendValue((CFMutableArrayRef)pCertName->emailAddress, str);
+            else if (memcmp(nvp.type.Data, CSSMOID_StateProvinceName.Data, CSSMOID_StateProvinceName.Length) == 0)
+                    CFArrayAppendValue((CFMutableArrayRef)pCertName->stateName, str);
+            else if (memcmp(nvp.type.Data, CSSMOID_LocalityName.Data, CSSMOID_LocalityName.Length) == 0)
+                    CFArrayAppendValue((CFMutableArrayRef)pCertName->localityName, str);
+            else if (memcmp(nvp.type.Data, CSSMOID_DistinguishedName.Data, CSSMOID_DistinguishedName.Length) == 0)
+                    CFArrayAppendValue((CFMutableArrayRef)pCertName->distinguishedName, str);
+
+            CFRelease(str);
+        }
+    }
+
+    return pCertName;
+}
+
+static CFArrayRef GetFieldsFromCssmCertData(CSSM_CL_HANDLE hCL, CSSM_DATA_PTR pCertData, CSSM_OID oid)
+{
+    CSSM_DATA_PTR pData = NULL;
+    CFMutableArrayRef fields = CFArrayCreateMutable(NULL, 0, NULL);
+    uint32 numFields, i;
+    CSSM_HANDLE ResultsHandle = (CSSM_HANDLE)NULL;
+    numFields = 0;
+
+    CSSM_CL_CertGetFirstFieldValue(hCL, pCertData, &oid, &ResultsHandle, &numFields, &pData);
+
+    if (!pData)
+    {
+        CSSM_CL_CertAbortQuery(hCL, ResultsHandle);
+        return NULL;
+    }
+
+    for (i = 0; i < numFields; i++)
+    {
+        CertNameRef pName = dataToName(pData);
+        CFArrayAppendValue(fields, pName);
+        CSSM_CL_FreeFieldValue (hCL, &oid, pData);
+        if (i < (numFields - 1))
+            CSSM_CL_CertGetNextFieldValue(hCL, ResultsHandle, &pData);
+    }
+
+    CSSM_CL_CertAbortQuery(hCL, ResultsHandle);
+    return fields;
+}
+
+static CFArrayRef GetFieldsFromCertificate(SecCertificateRef certificate, CSSM_OID oid)
+{
+    CSSM_CL_HANDLE hCL;
+    CSSM_DATA certData;
+    CFArrayRef fieldValues;
+
+    SecCertificateGetCLHandle(certificate, &hCL);
+    SecCertificateGetData(certificate, &certData);
+    fieldValues = GetFieldsFromCssmCertData(hCL, &certData, oid);
+
+    if (fieldValues == NULL)
+        return NULL;
+    else if (CFArrayGetCount(fieldValues) == 0)
+    {
+        CFRelease(fieldValues);
+        return NULL;
+    }
+
+    return fieldValues;
+}
+
+static CertDataRef createCertDataFromCertificate(SecCertificateRef certificate)
+{
+    CertDataRef pCertData = (CertDataRef)gc_malloc(sizeof(CertData), false, &g_gc);
+    pCertData->subject = GetFieldsFromCertificate(certificate, CSSMOID_X509V1SubjectNameCStruct);
+    pCertData->issuer = GetFieldsFromCertificate(certificate, CSSMOID_X509V1IssuerNameCStruct);
+
+    CSSM_DATA cssmCertData;
+    SecCertificateGetData (certificate, &cssmCertData);
+
+    unsigned char sha1[CC_SHA1_DIGEST_LENGTH];
+    CC_SHA1(cssmCertData.Data, cssmCertData.Length, sha1);
+    pCertData->sha1 = createHexString(sha1, CC_SHA1_DIGEST_LENGTH);
+
+    unsigned char md5[CC_MD5_DIGEST_LENGTH];
+    CC_MD5(cssmCertData.Data, cssmCertData.Length, md5);
+    pCertData->md5 = createHexString((unsigned char*)md5, CC_MD5_DIGEST_LENGTH);
+
+    return pCertData;
+}
+
+static CFStringRef stringFromRange(const char *cstring, CFRange range)
+{
+    CFStringRef str = CFStringCreateWithBytes (NULL, (uint8*)&cstring[range.location], range.length, kCFStringEncodingUTF8, false);
+    CFMutableStringRef mutableStr = CFStringCreateMutableCopy(NULL, 0, str);
+    CFStringTrimWhitespace(mutableStr);
+    CFRelease(str);
+    return mutableStr;
+}
+
+static DescDataRef createDescData(const char *description, CFRange nameRange, CFRange valueRange)
+{
+    DescDataRef pRetVal = (DescDataRef)gc_malloc(sizeof(DescData), false, &g_gc);
+
+    memset(pRetVal, 0, sizeof(DescData));
+
+    if (nameRange.length > 0)
+            pRetVal->name = stringFromRange(description, nameRange);
+
+    if (valueRange.length > 0)
+            pRetVal->value = stringFromRange(description, valueRange);
+
+    return pRetVal;
+}
+
+static void destroyDescData(DescDataRef pData)
+{
+    if (pData->name)
+        CFRelease(pData->name);
+
+    if (pData->value)
+        CFRelease(pData->value);
+}
+
+static CFArrayRef createDescDataPairs(const char *description)
+{
+    int numChars = strlen(description);
+    CFRange nameRange, valueRange;
+    DescDataRef pData;
+    CFMutableArrayRef retVal = CFArrayCreateMutable(NULL, 0, NULL);
+
+    int i = 0;
+
+    nameRange = CFRangeMake(0, 0);
+    valueRange = CFRangeMake(0, 0);
+    bool bInValue = false;
+
+    while(i < numChars)
+    {
+        if (!bInValue && (description[i] != ':'))
+            nameRange.length++;
+        else if (bInValue && (description[i] != ':'))
+            valueRange.length++;
+        else if(!bInValue)
+        {
+            bInValue = true;
+            valueRange.location = i + 1;
+            valueRange.length = 0;
+        }
+        else //(bInValue)
+        {
+            bInValue = false;
+            while(description[i] != ' ')
+            {
+                valueRange.length--;
+                i--;
+            }
+
+            pData = createDescData(description, nameRange, valueRange);
+            CFArrayAppendValue(retVal, pData);
+
+            nameRange.location = i + 1;
+            nameRange.length = 0;
+        }
+
+        i++;
+    }
+
+    pData = createDescData(description, nameRange, valueRange);
+    CFArrayAppendValue(retVal, pData);
+    return retVal;
+}
+
+static void arrayDestroyDescData(const void *val, void *context)
+{
+    DescDataRef pData = (DescDataRef) val;
+    destroyDescData(pData);
+}
+
+
+static void parseNameComponent(CFStringRef dn, CFStringRef *pName, CFStringRef *pValue)
+{
+    CFArrayRef nameStrings = CFStringCreateArrayBySeparatingStrings(NULL, dn, kCertNameEquals);
+
+    *pName = *pValue = NULL;
+
+    if (CFArrayGetCount(nameStrings) != 2)
+        return;
+
+    CFMutableStringRef str;
+
+    str = CFStringCreateMutableCopy(NULL, 0, CFArrayGetValueAtIndex(nameStrings, 0));
+    CFStringTrimWhitespace(str);
+    *pName = str;
+
+    str = CFStringCreateMutableCopy(NULL, 0, CFArrayGetValueAtIndex(nameStrings, 1));
+    CFStringTrimWhitespace(str);
+    *pValue = str;
+
+    CFRelease(nameStrings);
+}
+
+static void parseCertName(CFStringRef nameDesc, CFMutableArrayRef names)
+{
+    CFArrayRef nameStrings = CFStringCreateArrayBySeparatingStrings(NULL, nameDesc, kCertNameFwdSlash);
+    int count = CFArrayGetCount(nameStrings);
+    int i;
+
+    CertNameRef pCertName = createCertName();
+
+    for(i = 0;i < count;i++)
+    {
+        CFMutableStringRef dn = CFStringCreateMutableCopy(NULL, 0, CFArrayGetValueAtIndex(nameStrings, i));
+        CFStringTrimWhitespace(dn);
+
+        CFStringRef name, value;
+
+        parseNameComponent(dn, &name, &value);
+
+        if (!name || !value)
+        {
+            if (name)
+                CFRelease(name);
+
+            if (value)
+                CFRelease(value);
+
+            CFRelease(dn);
+            continue;
+        }
+
+        if (CFStringCompareWithOptions(name, kCertNameOrganization, CFRangeMake(0, CFStringGetLength(name)), kCFCompareCaseInsensitive) == kCFCompareEqualTo)
+            CFArrayAppendValue((CFMutableArrayRef)pCertName->organization, value);
+        else if (CFStringCompareWithOptions(name, kCertNameOrganizationalUnit, CFRangeMake(0, CFStringGetLength(name)), kCFCompareCaseInsensitive) == kCFCompareEqualTo)
+            CFArrayAppendValue((CFMutableArrayRef)pCertName->organizationalUnit, value);
+        else if (CFStringCompareWithOptions(name, kCertNameCountry, CFRangeMake(0, CFStringGetLength(name)), kCFCompareCaseInsensitive) == kCFCompareEqualTo)
+            CFArrayAppendValue((CFMutableArrayRef)pCertName->countryName, value);
+        else if (CFStringCompareWithOptions(name, kCertNameLocality, CFRangeMake(0, CFStringGetLength(name)), kCFCompareCaseInsensitive) == kCFCompareEqualTo)
+            CFArrayAppendValue((CFMutableArrayRef)pCertName->localityName, value);
+        else if (CFStringCompareWithOptions(name, kCertNameState, CFRangeMake(0, CFStringGetLength(name)), kCFCompareCaseInsensitive) == kCFCompareEqualTo)
+            CFArrayAppendValue((CFMutableArrayRef)pCertName->stateName, value);
+        else if (CFStringCompareWithOptions(name, kCertNameCommonName, CFRangeMake(0, CFStringGetLength(name)), kCFCompareCaseInsensitive) == kCFCompareEqualTo)
+            CFArrayAppendValue((CFMutableArrayRef)pCertName->commonName, value);
+        else if (CFStringCompareWithOptions(name, kCertNameEmail, CFRangeMake(0, CFStringGetLength(name)), kCFCompareCaseInsensitive) == kCFCompareEqualTo)
+            CFArrayAppendValue((CFMutableArrayRef)pCertName->emailAddress, value);
+        else if (CFStringCompareWithOptions(name, kCertNameDomainComponent, CFRangeMake(0, CFStringGetLength(name)), kCFCompareCaseInsensitive) == kCFCompareEqualTo)
+            CFArrayAppendValue((CFMutableArrayRef)pCertName->domainComponent, value);
+
+        CFRelease(name);
+        CFRelease(value);
+        CFRelease(dn);
+    }
+
+    CFArrayAppendValue(names, pCertName);
+    CFRelease(nameStrings);
+}
+
+static void arrayParseDescDataPair(const void *val, void *context)
+{
+    DescDataRef pDescData = (DescDataRef)val;
+    CertDataRef pCertData = (CertDataRef)context;
+
+    if (!pDescData->name || !pDescData->value)
+        return;
+
+    if (CFStringCompareWithOptions(pDescData->name, kCertDataSubjectName, CFRangeMake(0, CFStringGetLength(pDescData->name)), kCFCompareCaseInsensitive) == kCFCompareEqualTo)
+        parseCertName(pDescData->value, (CFMutableArrayRef)pCertData->subject);
+    else if (CFStringCompareWithOptions(pDescData->name, kCertDataIssuerName, CFRangeMake(0, CFStringGetLength(pDescData->name)), kCFCompareCaseInsensitive) == kCFCompareEqualTo)
+        parseCertName(pDescData->value, (CFMutableArrayRef)pCertData->issuer);
+    else if (CFStringCompareWithOptions(pDescData->name, kCertDataSha1Name, CFRangeMake(0, CFStringGetLength(pDescData->name)), kCFCompareCaseInsensitive) == kCFCompareEqualTo)
+        pCertData->sha1 = CFRetain(pDescData->value);
+    else if (CFStringCompareWithOptions(pDescData->name, kCertDataMd5Name, CFRangeMake(0, CFStringGetLength(pDescData->name)), kCFCompareCaseInsensitive) == kCFCompareEqualTo)
+        pCertData->md5 = CFRetain(pDescData->value);
+}
+
+static CertDataRef createCertDataFromString(const char *description)
+{
+    CertDataRef pCertData = (CertDataRef)gc_malloc(sizeof(CertData), false, &g_gc);
+    pCertData->subject = CFArrayCreateMutable(NULL, 0, NULL);
+    pCertData->issuer = CFArrayCreateMutable(NULL, 0, NULL);
+    pCertData->sha1 = NULL;
+    pCertData->md5 = NULL;
+
+    CFArrayRef pairs = createDescDataPairs(description);
+    CFArrayApplyFunction(pairs, CFRangeMake(0, CFArrayGetCount(pairs)), arrayParseDescDataPair, pCertData);
+    CFArrayApplyFunction(pairs, CFRangeMake(0, CFArrayGetCount(pairs)), arrayDestroyDescData, NULL);
+    CFRelease(pairs);
+    return pCertData;
+}
+
+static void arrayDestroyCertName(const void *val, void *context)
+{
+    CertNameRef pCertName = (CertNameRef)val;
+    destroyCertName(pCertName);
+}
+
+static void destroyCertData(CertDataRef pCertData)
+{
+    if (pCertData->subject)
+    {
+        CFArrayApplyFunction(pCertData->subject, CFRangeMake(0, CFArrayGetCount(pCertData->subject)), arrayDestroyCertName, NULL);
+        CFRelease(pCertData->subject);
+    }
+
+    if (pCertData->issuer)
+    {
+        CFArrayApplyFunction(pCertData->issuer, CFRangeMake(0, CFArrayGetCount(pCertData->issuer)), arrayDestroyCertName, NULL);
+        CFRelease(pCertData->issuer);
+    }
+
+    if (pCertData->sha1)
+        CFRelease(pCertData->sha1);
+
+    if (pCertData->md5)
+        CFRelease(pCertData->md5);
+}
+
+static bool stringArrayMatchesTemplate(CFArrayRef strings, CFArrayRef templateArray)
+{
+    int templateCount, stringCount, i;
+
+    templateCount = CFArrayGetCount(templateArray);
+
+    if (templateCount > 0)
+    {
+        stringCount = CFArrayGetCount(strings);
+        if (stringCount != templateCount)
+            return false;
+
+        for(i = 0;i < stringCount;i++)
+        {
+            CFStringRef str, template;
+
+            template = (CFStringRef)CFArrayGetValueAtIndex(templateArray, i);
+            str = (CFStringRef)CFArrayGetValueAtIndex(strings, i);
+
+            if (CFStringCompareWithOptions(template, str, CFRangeMake(0, CFStringGetLength(template)), kCFCompareCaseInsensitive) != kCFCompareEqualTo)
+                return false;
+        }
+    }
+
+    return true;
+}
+
+static bool certNameMatchesTemplate(CertNameRef pCertName, CertNameRef pTemplate)
+{
+    if (!stringArrayMatchesTemplate(pCertName->countryName, pTemplate->countryName))
+        return false;
+    else if (!stringArrayMatchesTemplate(pCertName->organization, pTemplate->organization))
+        return false;
+    else if (!stringArrayMatchesTemplate(pCertName->organizationalUnit, pTemplate->organizationalUnit))
+        return false;
+    else if (!stringArrayMatchesTemplate(pCertName->commonName, pTemplate->commonName))
+        return false;
+    else if (!stringArrayMatchesTemplate(pCertName->emailAddress, pTemplate->emailAddress))
+        return false;
+    else if (!stringArrayMatchesTemplate(pCertName->stateName, pTemplate->stateName))
+        return false;
+    else if (!stringArrayMatchesTemplate(pCertName->localityName, pTemplate->localityName))
+        return false;
+    else
+        return true;
+}
+
+static bool certNameArrayMatchesTemplate(CFArrayRef certNameArray, CFArrayRef templateArray)
+{
+    int templateCount, certCount, i;
+
+    templateCount = CFArrayGetCount(templateArray);
+
+    if (templateCount > 0)
+    {
+        certCount = CFArrayGetCount(certNameArray);
+        if (certCount != templateCount)
+            return false;
+
+        for(i = 0;i < certCount;i++)
+        {
+            CertNameRef pName, pTemplateName;
+
+            pTemplateName = (CertNameRef)CFArrayGetValueAtIndex(templateArray, i);
+            pName = (CertNameRef)CFArrayGetValueAtIndex(certNameArray, i);
+
+            if (!certNameMatchesTemplate(pName, pTemplateName))
+                return false;
+        }
+    }
+
+    return true;
+}
+
+static bool hexStringMatchesTemplate(CFStringRef str, CFStringRef template)
+{
+    if (template)
+    {
+        if (!str)
+            return false;
+
+        CFMutableStringRef strMutable, templateMutable;
+
+        strMutable = CFStringCreateMutableCopy(NULL, 0, str);
+        templateMutable = CFStringCreateMutableCopy(NULL, 0, template);
+
+        CFStringFindAndReplace(strMutable, kStringSpace, kStringEmpty, CFRangeMake(0, CFStringGetLength(strMutable)), 0);
+        CFStringFindAndReplace(templateMutable, kStringSpace, kStringEmpty, CFRangeMake(0, CFStringGetLength(templateMutable)), 0);
+
+        CFComparisonResult result = CFStringCompareWithOptions(templateMutable, strMutable, CFRangeMake(0, CFStringGetLength(templateMutable)), kCFCompareCaseInsensitive);
+
+        CFRelease(strMutable);
+        CFRelease(templateMutable);
+
+        if (result != kCFCompareEqualTo)
+            return false;
+    }
+
+    return true;
+}
+
+static bool certDataMatchesTemplate(CertDataRef pCertData, CertDataRef pTemplate)
+{
+    if (!certNameArrayMatchesTemplate(pCertData->subject, pTemplate->subject))
+        return false;
+
+    if (!certNameArrayMatchesTemplate(pCertData->issuer, pTemplate->issuer))
+        return false;
+
+    if (!hexStringMatchesTemplate(pCertData->sha1, pTemplate->sha1))
+        return false;
+
+    if (!hexStringMatchesTemplate(pCertData->md5, pTemplate->md5))
+        return false;
+
+    return true;
+}
+
+static SecIdentityRef findIdentity(CertDataRef pCertDataTemplate)
+{
+    SecIdentitySearchRef search;
+    SecIdentitySearchCreate(NULL, 0, &search);
+
+    SecIdentityRef identity;
+    while(SecIdentitySearchCopyNext(search, &identity) != errSecItemNotFound)
+    {
+        SecCertificateRef certificate;
+        SecIdentityCopyCertificate (identity, &certificate);
+
+        CertDataRef pCertData = createCertDataFromCertificate(certificate);
+        bool bMatches = certDataMatchesTemplate(pCertData, pCertDataTemplate);
+
+        destroyCertData(pCertData);
+        CFRelease(certificate);
+
+        if (bMatches)
+            break;
+        else
+        {
+            CFRelease(identity);
+            identity = NULL;
+        }
+    }
+
+    CFRelease(search);
+    return identity;
+}
+
+static CSSM_DATA signData(SecIdentityRef identity, CSSM_DATA dataBuf)
+{
+    SecKeyRef privateKey;
+
+    SecIdentityCopyPrivateKey(identity,  &privateKey);
+    const CSSM_ACCESS_CREDENTIALS *pCredentials;
+    SecKeyGetCredentials(privateKey, CSSM_ACL_AUTHORIZATION_SIGN, kSecCredentialTypeDefault, &pCredentials);
+
+    CSSM_CSP_HANDLE cspHandle;
+    SecKeyGetCSPHandle(privateKey, &cspHandle);
+
+    const CSSM_KEY *pCssmKey;
+    SecKeyGetCSSMKey (privateKey, &pCssmKey);
+
+    CSSM_DATA signBuf;
+    signBuf.Data = NULL;
+    signBuf.Length = 0;
+
+    if (!(pCssmKey->KeyHeader.KeyUsage & CSSM_KEYUSE_SIGN))
+    {
+        CFRelease(privateKey);
+        return signBuf;
+    }
+
+    CSSM_CC_HANDLE cryptoContextHandle;
+    CSSM_CSP_CreateSignatureContext(cspHandle, CSSM_ALGID_RSA, pCredentials, pCssmKey, &cryptoContextHandle);
+
+    CSSM_SignData(cryptoContextHandle, &dataBuf, 1, CSSM_ALGID_NONE, &signBuf);
+
+    CSSM_DeleteContext(cryptoContextHandle);
+    CFRelease(privateKey);
+    return signBuf;
+}
+
+static void freeSignature(SecIdentityRef identity, CSSM_DATA sigBuf)
+{
+    SecKeyRef privateKey;
+
+    SecIdentityCopyPrivateKey(identity,  &privateKey);
+
+    CSSM_CSP_HANDLE cspHandle;
+    SecKeyGetCSPHandle(privateKey, &cspHandle);
+
+    CSSM_API_MEMORY_FUNCS memFuncs;
+    CSSM_GetAPIMemoryFunctions(cspHandle, &memFuncs);
+
+    memFuncs.free_func(sigBuf.Data, memFuncs.AllocRef);
+}
+
+/* --- Everything above is private, everything below is public API --- */
+
+void extractCertificateFromIdentity(SecIdentityRef identity, void **blob, size_t *size)
+{
+    CSSM_DATA cssmCertData;
+    SecCertificateRef certificate;
+
+    SecIdentityCopyCertificate(identity, &certificate);
+    SecCertificateGetData(certificate, &cssmCertData);
+    CFRelease(certificate);
+
+    *blob = cssmCertData.Data;
+    *length = cssmCertData.Length;
+}
+
+SecIdentityRef findIdentityByString(const char *description)
+{
+    initCertData();
+
+    CertDataRef pCertDataTemplate = createCertDataFromString(description);
+    SecIdentityRef identity = findIdentity(pCertDataTemplate);
+    destroyCertData(pCertDataTemplate);
+
+    freeCertData();
+
+    return identity;
+}
+
+void cryptoSignData(SecIdentityRef identity, const unsigned char *data, size_t size, unsigned char *signature)
+{
+    CSSM_DATA fromData;
+    fromData.Data = (uint8*)data;
+    fromData.Length = size;
+
+    CSSM_DATA sigBuf = signData(identity, fromData);
+    memcpy(signature, sigBuf.Data, sigBuf.Length);
+    freeSignature(identity, sigBuf);
+}
+
+#endif

--- a/src/openvpn/macosx.c
+++ b/src/openvpn/macosx.c
@@ -48,8 +48,7 @@
 CFStringRef kCertDataSubjectName = CFSTR("subject"),
     kCertDataIssuerName = CFSTR("issuer"), kCertDataSha1Name = CFSTR("SHA1"),
     kCertDataMd5Name = CFSTR("MD5"), kCertNameFwdSlash = CFSTR("/"),
-    kCertNameEquals = CFSTR("="),
-    CFStringRef kCertNameOrganization = CFSTR("o"),
+    kCertNameEquals = CFSTR("="), kCertNameOrganization = CFSTR("o"),
     kCertNameOrganizationalUnit = CFSTR("ou"), kCertNameCountry = CFSTR("c"),
     kCertNameLocality = CFSTR("l"), kCertNameState = CFSTR("st"),
     kCertNameCommonName = CFSTR("cn"), kCertNameEmail = CFSTR("e"),
@@ -718,7 +717,7 @@ void extractCertificateFromIdentity(SecIdentityRef identity, void **blob, size_t
     CFRelease(certificate);
 
     *blob = cssmCertData.Data;
-    *length = cssmCertData.Length;
+    *size = cssmCertData.Length;
 }
 
 SecIdentityRef findIdentityByString(const char *description)

--- a/src/openvpn/macosx.h
+++ b/src/openvpn/macosx.h
@@ -1,0 +1,46 @@
+/*
+ *  OpenVPN -- An application to securely tunnel IP networks
+ *             over a single UDP port, with support for SSL/TLS-based
+ *             session authentication and key exchange,
+ *             packet encryption, packet authentication, and
+ *             packet compression.
+ *
+ *  Copyright (C) 2010 Brian Raderman <brian@irregularexpression.org>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2
+ *  as published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program (see the file COPYING included with this
+ *  distribution); if not, write to the Free Software Foundation, Inc.,
+ *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ *  This is a concatenation of code originally in cert_data.h and crypto_osx.h,
+ *  both by Brian Raderman <brian@irregularexpression.org> done by
+ *  Radu - Eosif Mihailescu <rmihailescu@google.com>
+ */
+
+/*
+ * Mac OS X-specific OpenVPN code.
+ */
+
+#ifdef MACOSX
+#ifndef OPENVPN_MACOSX_H
+#define OPENVPN_MACOSX_H
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
+#include <stddef.h>
+
+SecIdentityRef findIdentityByString(const char *description);
+void extractCertificateFromIdentity(SecIdentityRef identity, void **blob, size_t *size);
+void cryptoSignData(SecIdentityRef identity, const unsigned char *data, size_t size, unsigned char *signature);
+
+#endif
+#endif

--- a/src/openvpn/options.h
+++ b/src/openvpn/options.h
@@ -546,6 +546,14 @@ struct options
   const char *cryptoapi_cert;
 #endif
 
+#ifdef ENABLE_KEYCHAIN
+  const char *keychain_cert;
+#endif
+
+   /* data channel key exchange method */
+   int key_method;
+
+
   /* data channel key exchange method */
   int key_method;
 

--- a/src/openvpn/options.h
+++ b/src/openvpn/options.h
@@ -550,10 +550,6 @@ struct options
   const char *keychain_cert;
 #endif
 
-   /* data channel key exchange method */
-   int key_method;
-
-
   /* data channel key exchange method */
   int key_method;
 

--- a/src/openvpn/ssl.c
+++ b/src/openvpn/ssl.c
@@ -506,6 +506,12 @@ init_ssl (const struct options *options, struct tls_root_ctx *new_ctx)
       tls_ctx_load_cryptoapi(new_ctx, options->cryptoapi_cert);
     }
 #endif
+#ifdef ENABLE_KEYCHAIN
+  else if (options->keychain_cert)
+    {
+      tls_ctx_load_keychain(new_ctx, options->keychain_cert);
+    }
+#endif
 #ifdef MANAGMENT_EXTERNAL_KEY
   else if ((options->management_flags & MF_EXTERNAL_KEY) && options->cert_file)
     {

--- a/src/openvpn/ssl_backend.h
+++ b/src/openvpn/ssl_backend.h
@@ -206,11 +206,22 @@ int tls_ctx_load_pkcs12(struct tls_root_ctx *ctx, const char *pkcs12_file,
  * context.
  *
  * @param ctx			TLS context to use
- * @param crypto_api_cert	String representing the certificate to load.
+ * @param cryptoapi_cert	String representing the certificate to load.
  */
 #ifdef ENABLE_CRYPTOAPI
 void tls_ctx_load_cryptoapi(struct tls_root_ctx *ctx, const char *cryptoapi_cert);
-#endif /* WIN32 */
+#endif /* ENABLE_CRYPTOAPI */
+
+/**
+ * Use Apple Mac OS X Keychain for key and cert, and add to library-specific TLS
+ * context.
+ *
+ * @param ctx			TLS context to use
+ * @param keychain_cert	String representing the certificate to load.
+ */
+#ifdef ENABLE_KEYCHAIN
+void tls_ctx_load_keychain(struct tls_root_ctx *ctx, const char *keychain_cert);
+#endif /* ENABLE_KEYCHAIN */
 
 /**
  * Load certificate file into the given TLS context. If the given certificate

--- a/src/openvpn/ssl_openssl.c
+++ b/src/openvpn/ssl_openssl.c
@@ -50,6 +50,10 @@
 #include "cryptoapi.h"
 #endif
 
+#ifdef ENABLE_KEYCHAIN
+#include "keychain.h"
+#endif
+
 #include "ssl_verify_openssl.h"
 
 #include <openssl/err.h>
@@ -446,7 +450,20 @@ tls_ctx_load_cryptoapi(struct tls_root_ctx *ctx, const char *cryptoapi_cert)
     msg (M_SSLERR, "Cannot load certificate \"%s\" from Microsoft Certificate Store",
 	   cryptoapi_cert);
 }
-#endif /* WIN32 */
+#endif /* ENABLE_CRYPTOAPI */
+
+#ifdef ENABLE_KEYCHAIN
+void
+tls_ctx_load_keychain(struct tls_root_ctx *ctx, const char *keychain_cert)
+{
+  ASSERT(NULL != ctx);
+
+  /* Load Certificate and Private Key */
+  if (!SSL_CTX_use_Keychain_certificate (ctx->ctx, keychain_cert))
+    msg (M_SSLERR, "Cannot load certificate \"%s\" from Apple Keychain Store",
+	   keychain_cert);
+}
+#endif /* ENABLE_KEYCHAIN */
 
 static void
 tls_ctx_add_extra_certs (struct tls_root_ctx *ctx, BIO *bio)

--- a/src/openvpn/ssl_polarssl.c
+++ b/src/openvpn/ssl_polarssl.c
@@ -244,7 +244,15 @@ tls_ctx_load_cryptoapi(struct tls_root_ctx *ctx, const char *cryptoapi_cert)
 {
   msg(M_FATAL, "Windows CryptoAPI not yet supported for PolarSSL.");
 }
-#endif /* WIN32 */
+#endif /* ENABLE_CRYPTOAPI */
+
+#ifdef ENABLE_KEYCHAIN
+void
+tls_ctx_load_keychain(struct tls_root_ctx *ctx, const char *keychain_cert)
+{
+  msg(M_FATAL, "Apple Mac OS X Keychain not yet supported for PolarSSL.");
+}
+#endif /* ENABLE_KEYCHAIN */
 
 void
 tls_ctx_load_cert_file (struct tls_root_ctx *ctx, const char *cert_file,

--- a/src/openvpn/syshead.h
+++ b/src/openvpn/syshead.h
@@ -632,7 +632,7 @@ socket_defined (const socket_descriptor_t sd)
 /*
  * Do we have Apple Keychain capability?
  */
-#if defined(__APPLE__) && defined(ENABLE_CRYPTO) && defined(ENABLE_SSL) && defined(ENABLE_CRYPTO_OPENSSL)
+#if defined(MACOSX) && defined(ENABLE_CRYPTO) && defined(ENABLE_SSL) && defined(ENABLE_CRYPTO_OPENSSL)
 #define ENABLE_KEYCHAIN
 #endif
 

--- a/src/openvpn/syshead.h
+++ b/src/openvpn/syshead.h
@@ -623,10 +623,17 @@ socket_defined (const socket_descriptor_t sd)
 #endif
 
 /*
- * Do we have CryptoAPI capability?
+ * Do we have Microsoft CryptoAPI capability?
  */
 #if defined(WIN32) && defined(ENABLE_CRYPTO) && defined(ENABLE_SSL) && defined(ENABLE_CRYPTO_OPENSSL)
 #define ENABLE_CRYPTOAPI
+#endif
+
+/*
+ * Do we have Apple Keychain capability?
+ */
+#if defined(__APPLE__) && defined(ENABLE_CRYPTO) && defined(ENABLE_SSL) && defined(ENABLE_CRYPTO_OPENSSL)
+#define ENABLE_KEYCHAIN
 #endif
 
 /*

--- a/src/openvpn/syshead.h
+++ b/src/openvpn/syshead.h
@@ -37,6 +37,18 @@
 # define unlikely(x)    (x)
 #endif
 
+#ifdef TARGET_WIN32
+#ifndef WIN32
+#define WIN32
+#endif
+#endif
+
+#ifdef TARGET_DARWIN
+#ifndef MACOSX
+#define MACOSX
+#endif
+#endif
+
 #ifdef WIN32
 #include <windows.h>
 #include <winsock2.h>


### PR DESCRIPTION

(rebased on HEAD, as requested)

Hello,

This is a resurrection of the original patch submitted by Bran Raderman brian@irregularexpression.org four years ago. I took the liberty of porting the patch to the current OpenVPN source style and layout, while at the same time adapting it to follow in the footsteps of the Microsoft CryptoAPI support as closely as possible.

This has been tested to work fine on Mac OS X 10.9.1 using a binary compiled using the XCode 4.x command line tools and GNU autotools installed using brew.

Please have a look,
Kind regards,
Radu - Eosif Mihailescu
