### PR TITLE
Add topology in sample server configuration file

### DIFF
--- a/sample/sample-config-files/server.conf
+++ b/sample/sample-config-files/server.conf
@@ -86,6 +86,13 @@ key server.key  # This file should be kept secret
 # 2048 bit keys. 
 dh dh1024.pem
 
+# Network topology
+# Should be subnet (addressing via IP)
+# unless Windows clients v2.0.9 and lower have to
+# be supported (then net30, i.e. a /30 per client)
+# Defaults to net30 (not recommended)
+;topology subnet
+
 # Configure server mode and supply a VPN subnet
 # for OpenVPN to draw client addresses from.
 # The server will take 10.8.0.1 for itself,


### PR DESCRIPTION
On modern systems, topology subnet should always be set, but it's missing in the configuration file.
Add it with a short explanation.
