### PR TITLE
systemd: Improve handling of runtime directory.

### DIFF
--- a/distro/systemd/openvpn-client@.service
+++ b/distro/systemd/openvpn-client@.service
@@ -8,11 +8,10 @@ Documentation=https://community.openvpn.net/openvpn/wiki/HOWTO
 
 [Service]
 PrivateTmp=true
-Type=forking
 RuntimeDirectory=openvpn
 RuntimeDirectoryMode=0710
-PIDFile=%t/openvpn/client_%i.pid
-ExecStart=/usr/sbin/openvpn --cd /etc/openvpn/client --config %i.conf --daemon --writepid %t/openvpn/client_%i.pid
+WorkingDirectory=/etc/openvpn/client
+ExecStart=/usr/sbin/openvpn --config %i.conf --suppress-timestamps
 CapabilityBoundingSet=CAP_IPC_LOCK CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_RAW CAP_SETGID CAP_SETUID CAP_SYS_CHROOT CAP_DAC_READ_SEARCH
 LimitNPROC=10
 DeviceAllow=/dev/null rw

--- a/distro/systemd/openvpn-client@.service
+++ b/distro/systemd/openvpn-client@.service
@@ -9,8 +9,10 @@ Documentation=https://community.openvpn.net/openvpn/wiki/HOWTO
 [Service]
 PrivateTmp=true
 Type=forking
-PIDFile=/var/run/openvpn/client_%i.pid
-ExecStart=/usr/sbin/openvpn --cd /etc/openvpn/client --config %i.conf --daemon --writepid /var/run/openvpn/client_%i.pid
+RuntimeDirectory=openvpn
+RuntimeDirectoryMode=0710
+PIDFile=%t/openvpn/client_%i.pid
+ExecStart=/usr/sbin/openvpn --cd /etc/openvpn/client --config %i.conf --daemon --writepid %t/openvpn/client_%i.pid
 CapabilityBoundingSet=CAP_IPC_LOCK CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_RAW CAP_SETGID CAP_SETUID CAP_SYS_CHROOT CAP_DAC_READ_SEARCH
 LimitNPROC=10
 DeviceAllow=/dev/null rw

--- a/distro/systemd/openvpn-server@.service
+++ b/distro/systemd/openvpn-server@.service
@@ -8,8 +8,10 @@ Documentation=https://community.openvpn.net/openvpn/wiki/HOWTO
 [Service]
 PrivateTmp=true
 Type=forking
-PIDFile=/var/run/openvpn/server_%i.pid
-ExecStart=/usr/sbin/openvpn --cd /etc/openvpn/server --status /var/run/openvpn/server_%i-status.log --status-version 2 --config %i.conf --daemon --writepid /var/run/openvpn/server_%i.pid
+RuntimeDirectory=openvpn
+RuntimeDirectoryMode=0710
+PIDFile=%t/openvpn/server_%i.pid
+ExecStart=/usr/sbin/openvpn --cd /etc/openvpn/server --status %t/openvpn/server_%i-status.log --status-version 2 --config %i.conf --daemon --writepid %t/openvpn/server_%i.pid
 CapabilityBoundingSet=CAP_IPC_LOCK CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_RAW CAP_SETGID CAP_SETUID CAP_SYS_CHROOT CAP_DAC_READ_SEARCH
 LimitNPROC=10
 DeviceAllow=/dev/null rw

--- a/distro/systemd/openvpn-server@.service
+++ b/distro/systemd/openvpn-server@.service
@@ -7,11 +7,10 @@ Documentation=https://community.openvpn.net/openvpn/wiki/HOWTO
 
 [Service]
 PrivateTmp=true
-Type=forking
 RuntimeDirectory=openvpn
 RuntimeDirectoryMode=0710
-PIDFile=%t/openvpn/server_%i.pid
-ExecStart=/usr/sbin/openvpn --cd /etc/openvpn/server --status %t/openvpn/server_%i-status.log --status-version 2 --config %i.conf --daemon --writepid %t/openvpn/server_%i.pid
+WorkingDirectory=/etc/openvpn/server
+ExecStart=/usr/sbin/openvpn --status %t/openvpn/server_%i-status.log --status-version 2 --config %i.conf --suppress-timestamps
 CapabilityBoundingSet=CAP_IPC_LOCK CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_RAW CAP_SETGID CAP_SETUID CAP_SYS_CHROOT CAP_DAC_READ_SEARCH
 LimitNPROC=10
 DeviceAllow=/dev/null rw


### PR DESCRIPTION
- Don't hardcode `/var/run` but use `%t` instead to determine the
  runtime base directory depending on the environment

- Define `RuntimeDirectory=` and `RuntimeDirectoryMode=` to create e.g.
  `/run/openvpn` on demand when it's non-existent