### PR TITLE
__func__ is not supported on Visual Studio 2010. Replace it with a macro

### DIFF
--- a/src/openvpn/crypto.c
+++ b/src/openvpn/crypto.c
@@ -423,7 +423,7 @@ crypto_adjust_frame_parameters(struct frame *frame,
   frame_add_to_extra_frame (frame, crypto_overhead);
 
   msg(D_MTU_DEBUG, "%s: Adjusting frame parameters for crypto by %zu bytes",
-      __func__, crypto_overhead);
+      CURRENT_FUNCTION, crypto_overhead);
 }
 
 /*

--- a/src/openvpn/crypto.h
+++ b/src/openvpn/crypto.h
@@ -459,6 +459,15 @@ key_ctx_bi_defined(const struct key_ctx_bi* key)
   return key->encrypt.cipher || key->encrypt.hmac || key->decrypt.cipher || key->decrypt.hmac;
 }
 
+/*
+ * __func__ is not yet supported on Visual Studio 2013
+ */
+
+#ifdef _MSC_VER
+    #define CURRENT_FUNCTION __FUNCTION__
+#else
+    #define CURRENT_FUNCTION __func__
+#endif
 
 #endif /* ENABLE_CRYPTO */
 #endif /* CRYPTO_H */


### PR DESCRIPTION
:-)

(After double-checking, I found out that I was using the compiler in VS 2010, not 2013)