### PR TITLE
connection management: Implement session timeout parameter.

### DIFF
--- a/src/openvpn/forward-inline.h
+++ b/src/openvpn/forward-inline.h
@@ -118,6 +118,19 @@ check_inactivity_timeout (struct context *c)
     check_inactivity_timeout_dowork (c);
 }
 
+/*
+ * Should we exit due to session timeout?
+ */
+static inline void
+check_session_timeout (struct context *c)
+{
+  void check_session_timeout_dowork (struct context *c);
+
+  if (c->options.session_timeout
+      && event_timeout_trigger (&c->c2.session_interval, &c->c2.timeval, ETT_DEFAULT))
+    check_session_timeout_dowork (c);
+}
+
 #if P2MP
 
 static inline void

--- a/src/openvpn/forward.c
+++ b/src/openvpn/forward.c
@@ -322,6 +322,16 @@ check_inactivity_timeout_dowork (struct context *c)
   register_signal (c, SIGTERM, "inactive");
 }
 
+/*
+ * Should we exit due to session timeout?
+ */
+void
+check_session_timeout_dowork (struct context *c)
+{
+  msg (M_INFO, "Session timeout (--session), exiting");
+  register_signal (c, SIGTERM, "session");
+}
+
 #if P2MP
 
 void
@@ -527,6 +537,11 @@ process_coarse_timers (struct context *c)
   if (c->sig->signal_received)
     return;
 
+  /* possibly exit due to --session */
+  check_session_timeout (c);
+  if (c->sig->signal_received)
+    return;
+  
   /* restart if ping not received */
   check_ping_restart (c);
   if (c->sig->signal_received)

--- a/src/openvpn/init.c
+++ b/src/openvpn/init.c
@@ -1064,6 +1064,10 @@ do_init_timers (struct context *c, bool deferred)
   if (c->options.inactivity_timeout)
     event_timeout_init (&c->c2.inactivity_interval, c->options.inactivity_timeout, now);
 
+  /* initialize session timeout */
+  if (c->options.session_timeout)
+    event_timeout_init (&c->c2.session_interval, c->options.session_timeout, now);
+
   /* initialize pings */
 
   if (c->options.ping_send_timeout)

--- a/src/openvpn/openvpn.h
+++ b/src/openvpn/openvpn.h
@@ -299,6 +299,9 @@ struct context_2
   struct event_timeout inactivity_interval;
   int inactivity_bytes;
 
+  /* --session */
+  struct event_timeout session_interval;
+  
 #ifdef ENABLE_OCC
   /* the option strings must match across peers */
   char *options_string_local;

--- a/src/openvpn/options.c
+++ b/src/openvpn/options.c
@@ -247,6 +247,7 @@ static const char usage_message[] =
   "                  for m seconds.\n"
   "--inactive n [bytes] : Exit after n seconds of activity on tun/tap device\n"
   "                  produces a combined in/out byte count < bytes.\n"
+  "--session n     : Limit connection time to n seconds\n"
   "--ping-exit n   : Exit if n seconds pass without reception of remote ping.\n"
   "--ping-restart n: Restart if n seconds pass without reception of remote ping.\n"
   "--ping-timer-rem: Run the --ping-exit/--ping-restart timer only if we have a\n"
@@ -1450,6 +1451,7 @@ show_settings (const struct options *o)
   SHOW_INT (keepalive_ping);
   SHOW_INT (keepalive_timeout);
   SHOW_INT (inactivity_timeout);
+  SHOW_INT (session_timeout);
   SHOW_INT (ping_send_timeout);
   SHOW_INT (ping_rec_timeout);
   SHOW_INT (ping_rec_timeout_action);
@@ -4990,6 +4992,11 @@ add_option (struct options *options,
       options->inactivity_timeout = positive_atoi (p[1]);
       if (p[2])
 	options->inactivity_minimum_bytes = positive_atoi (p[2]);
+    }
+  else if (streq (p[0], "session") && p[1])
+    {
+      VERIFY_PERMISSION (OPT_P_TIMER);
+      options->session_timeout = positive_atoi (p[1]);
     }
   else if (streq (p[0], "proto") && p[1])
     {

--- a/src/openvpn/options.h
+++ b/src/openvpn/options.h
@@ -253,6 +253,8 @@ struct options
   int inactivity_timeout;       /* --inactive */
   int inactivity_minimum_bytes;
 
+  int session_timeout;          /* --session */
+  
   int ping_send_timeout;        /* Send a TCP/UDP ping to remote every n seconds */
   int ping_rec_timeout;         /* Expect a TCP/UDP ping from remote at least once every n seconds */
   bool ping_timer_remote;       /* Run ping timer only if we have a remote address */


### PR DESCRIPTION
In multiple case it is important to limit user connection time. At the moment it is only
possible by using management console and writing complicated script to follow connection status.

There is an easier way to do that now. "session" parameter allows to define timeout in seconds
after which user will be disconnected. Session timeout can be declared globally or per user in
ccd file. Session is started at the moment user connects to VPN and will be automatically terminated
when timer reaches the zero.

This feature can be used together with Radiusplugin for OpenVPN in order to support Session-Timeout attribute.

Patch for Radiusplugin is coming as well.
