### PR TITLE
options: allow for options to "plugin"

### DIFF
--- a/src/openvpn/options.c
+++ b/src/openvpn/options.c
@@ -4325,7 +4325,7 @@ add_option (struct options *options,
     }
 #endif
 #ifdef ENABLE_PLUGIN
-  else if (streq (p[0], "plugin") && p[1] && !p[2])
+  else if (streq (p[0], "plugin") && p[1] && !p[3])
     {
       VERIFY_PERMISSION (OPT_P_PLUGIN);
       if (!options->plugin_list)


### PR DESCRIPTION
This is required for the down-root plugin, and regressed in 3d6a4cd
(https://community.openvpn.net/openvpn/ticket/557).

/cc @jkbullard @cron2 