### PR TITLE
systemd: client: use KillMode=mixed

### DIFF
--- a/distro/systemd/openvpn-client@.service
+++ b/distro/systemd/openvpn-client@.service
@@ -15,6 +15,7 @@ CapabilityBoundingSet=CAP_IPC_LOCK CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_RA
 LimitNPROC=10
 DeviceAllow=/dev/null rw
 DeviceAllow=/dev/net/tun rw
+KillMode=mixed
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The default ("control-group") will prevent the down-root plugin to
communicate with the forked process correctly.

Fixes https://community.openvpn.net/openvpn/ticket/581.
Reported for Debian at: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=792907