### PR TITLE
Clear input buffer properly in get_console_input_systemd()

### DIFF
--- a/src/openvpn/console.c
+++ b/src/openvpn/console.c
@@ -172,7 +172,7 @@ get_console_input_systemd (const char *prompt, const bool echo, char *input, con
   if ((std_out = openvpn_popen (&argv, NULL)) < 0) {
 	  return false;
   }
-  CLEAR (*input);
+  memset (input, 0, capacity);
   if (read (std_out, input, capacity) != 0)
     {
        chomp (input);


### PR DESCRIPTION
The CLEAR macro won't work here because the size of the input buffer is not known. This causes random garbage to be sent as the static challenge response, usually resulting in an error on the Access Server like
```
VPN Auth Failed: "'utf8' codec can't decode byte 0xd0 in position 9: invalid continuation byte: omi/auth:454,auth/domuserpass:97,auth/pwresp:21,util/types:21,encodings/utf_8:16 (exceptions.UnicodeDecodeError)" [None]
```
Strangely, I could not reproduce the error when the response was six characters, as is the case for Google Authenticator codes. The bug only reared its ugly head to us when a user tried to authenticate with an eight-digit backup code.