### PR TITLE
Compiling only entire statements with preprocessor conditionals.

### DIFF
--- a/src/openvpn/socket.c
+++ b/src/openvpn/socket.c
@@ -802,14 +802,15 @@ create_socket_udp (struct addrinfo* addrinfo, const unsigned int flags)
       else if (addrinfo->ai_family == AF_INET6 )
         {
 #ifndef IPV6_RECVPKTINFO /* Some older Darwin platforms require this */
-          if (setsockopt (sd, IPPROTO_IPV6, IPV6_PKTINFO,
-                          (void*)&pad, sizeof(pad)) < 0)
+          bool failed = (setsockopt (sd, IPPROTO_IPV6, IPV6_PKTINFO,
+                            (void*)&pad, sizeof(pad)) < 0);
 #else
-          if (setsockopt (sd, IPPROTO_IPV6, IPV6_RECVPKTINFO,
-                          (void*)&pad, sizeof(pad)) < 0)
+          bool failed = (setsockopt (sd, IPPROTO_IPV6, IPV6_RECVPKTINFO,
+                            (void*)&pad, sizeof(pad)) < 0);
 #endif
-            msg(M_ERR, "UDP: failed setsockopt for IPV6_RECVPKTINFO");
-        }
+          if (failed) {
+          	msg(M_ERR, "UDP: failed setsockopt for IPV6_RECVPKTINFO");
+          }
     }
 #endif
   return sd;


### PR DESCRIPTION
A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

- https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
- https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/

It might improve code understanding, maintainability and error-proneness.