### PR TITLE
netconfig: fixed ipv6 netbits to 126 (4 hosts)

### DIFF
--- a/src/openvpn/options.c
+++ b/src/openvpn/options.c
@@ -4436,9 +4436,9 @@ add_option (struct options *options,
       if ( get_ipv6_addr( p[1], NULL, &netbits, msglevel ) &&
            ipv6_addr_safe( p[2] ) )
         {
-	  if ( netbits < 64 || netbits > 124 )
+	  if ( netbits < 64 || netbits > 126 )
 	    {
-	      msg( msglevel, "ifconfig-ipv6: /netbits must be between 64 and 124, not '/%d'", netbits );
+	      msg( msglevel, "ifconfig-ipv6: /netbits must be between 64 and 126, not '/%d'", netbits );
 	      goto err;
 	    }
 


### PR DESCRIPTION
I tryed to configure a IPv6 Tunnel Network with 4 IP's and due to the wrong 124 Bit limit, it is not possible at the moment. Therfore I would suggest the fix to set maximum netmask to 126 Bits, the same as in IPv4 a /30 represents.
