### PR TITLE
testing: Add vagrant based integration tests

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -309,11 +309,17 @@ AC_ARG_WITH(
 )
 
 
+# Test if ld supports '--wrap' whcih currently is only supported on Linux
+# http://www.mockator.com/projects/mockator/wiki/Wrap_Functions
+AM_CONDITIONAL([SUPPORT_LD_WRAP], [ false ])
+
 AC_DEFINE_UNQUOTED([TARGET_ALIAS], ["${host}"], [A string representing our host])
 case "$host" in
 	*-*-linux*)
 		AC_DEFINE([TARGET_LINUX], [1], [Are we running on Linux?])
 		AC_DEFINE_UNQUOTED([TARGET_PREFIX], ["L"], [Target prefix])
+                # It might be better to actually run ld with --wrap
+                AM_CONDITIONAL([SUPPORT_LD_WRAP], [ true ])
 		;;
 	*-*-solaris*)
 		AC_DEFINE([TARGET_SOLARIS], [1], [Are we running on Solaris?])
@@ -1262,6 +1268,10 @@ TEST_CFLAGS="-I\$(top_srcdir)/include -I\$(abs_top_builddir)/vendor/dist/include
 
 AC_SUBST([TEST_LDFLAGS])
 AC_SUBST([TEST_CFLAGS])
+
+# Test if ld supports '--wrap' whcih currently is only supported on Linux
+# http://www.mockator.com/projects/mockator/wiki/Wrap_Functions
+AM_CONDITIONAL([SUPPORT_LD_WRAP], [TARGET_LINUX])
 
 # Check if cmake is available and cmocka git submodule is initialized,
 # needed for unit testing

--- a/tests/server/.gitignore
+++ b/tests/server/.gitignore
@@ -1,0 +1,1 @@
+.vagrant/

--- a/tests/server/README.md
+++ b/tests/server/README.md
@@ -1,0 +1,45 @@
+VM definitions for test servers
+================================
+
+Virtual machines defined by [Vagrant](https://www.vagrantup.com) scripts. Virtualbox is used for virtualisation.
+
+Each of the virtual machines is configured to compile openvpn and run a server.
+
+Inside the vm a openvpn server can be launched to run `t_client.sh` tests against it.
+
+Use Cases:
+---------------
+ 
+### Start the VM:
+  * `vagrant up` from inside the VMs folder (e.g. `centos7`)
+
+### Login to  the VM:
+  * `vagrant ssh`
+
+### Synchronize local changes into the VM & rebuild the server
+  * (insinde the vm)
+  *  `/scripts/sync_codebase.sh`
+  *  `/scripts/compile.sh`
+
+### Start the server for  `t_client` tests
+  * (outside of the vm) Modify `t_client.rc` ( `REMOTE_IP`, `REMOTE_PORT`, `SERVER_KEY`, `SERVER_CERT`
+  * (inside the vm) run `/scripts/sync_codebase.sh` (to sync the changed `t_client.rc`)
+  * (inside the vm) run `/scripts/compile.sh`
+  * (inside the vm) run `/scripts/start_server.sh`
+
+VM Layout
+-----------
+ * The original source tree is mounted at /openvpn
+ * The source tree used for compilation is copied to `~vagrant/openvpn`
+ * Scripts are installed in the /scripts directory
+   * `sync_codebase.sh` copies the codebase from the host into ~/openvpn ( so that it can be compiled for the VMs architecture/OS)
+   * `rebuild.sh` builds the server inside the VM (at ~/openvpn)
+   * `start_server.sh` starts the server with a configuration from t_client.rc
+
+provided VMs
+--------------
+
+| Name                     | external IPv4   | external IPv6              |
+|--------------------------|-----------------|----------------------------|
+| ubuntu_trusty64          | 192.168.33.66   | IPv4 only                  |
+| ubuntu_precise64         | 192.168.33.67   | IPv4 only                  |

--- a/tests/server/README.md
+++ b/tests/server/README.md
@@ -7,28 +7,29 @@ Each of the virtual machines is configured to compile openvpn and run a server.
 
 Inside the vm a openvpn server can be launched to run `t_client.sh` tests against it.
 
-Use Cases:
----------------
+Low Level Use Cases
+========================
+
+These use cases center around virtual machine creation, compilation of openvpn inside the VM, and running `t_client.sh`.
  
-### Start the VM:
-  * `vagrant up` from inside the VMs folder (e.g. `centos7`)
+## Start the VM:
+  * `vagrant up` from inside the VMs folder (e.g. `ubuntu_trusty64`)
 
-### Login to  the VM:
-  * `vagrant ssh`
+## Login to  the VM:
+  * `vagrant ssh` from inside the VMs folder (e.g. `ubuntu_trusty64`)
 
-### Synchronize local changes into the VM & rebuild the server
+## Synchronize local changes into the VM & rebuild the server
   * (insinde the vm)
   *  `/scripts/sync_codebase.sh`
   *  `/scripts/compile.sh`
 
-### Start the server for  `t_client` tests
-  * (outside of the vm) Modify `t_client.rc` ( `REMOTE_IP`, `REMOTE_PORT`, `SERVER_KEY`, `SERVER_CERT`
+## Start the server for  `t_client` tests
+  * (outside of the vm) Modify `t_client.rc` ( `REMOTE_IP`, `REMOTE_PORT`, `SERVER_KEY`, `SERVER_CERT`)
   * (inside the vm) run `/scripts/sync_codebase.sh` (to sync the changed `t_client.rc`)
   * (inside the vm) run `/scripts/compile.sh`
   * (inside the vm) run `/scripts/start_server.sh`
 
-VM Layout
------------
+## VM Layout
  * The original source tree is mounted at /openvpn
  * The source tree used for compilation is copied to `~vagrant/openvpn`
  * Scripts are installed in the /scripts directory
@@ -36,8 +37,16 @@ VM Layout
    * `rebuild.sh` builds the server inside the VM (at ~/openvpn)
    * `start_server.sh` starts the server with a configuration from t_client.rc
 
-provided VMs
---------------
+## add a VM
+
+The easiest way to create a new VM is so adapt the templates already provided.
+
+ * Create a new directory with the VM name under `tests/server`
+ * Create a `Vagrantfile` that mimics the files in e.g. `ubuntu_trusty64`. Pick a dedicated IP (optionally)
+ * Create a  `launch_t_client.sh` wrapper, passing the servers IP to `t_client.sh`
+
+
+## provided VMs
 
 | Name                     | external IPv4   | external IPv6              |
 |--------------------------|-----------------|----------------------------|

--- a/tests/server/run_integration.sh
+++ b/tests/server/run_integration.sh
@@ -147,7 +147,7 @@ colorize() {
 
   msg=${msg/FATAL/${ERROR}FATAL${color}}
   msg=${msg/FAIL/${ERROR}FAIL${color}}
-  echo $msg
+  echo "$msg"
 }
 
 # $1 : Source/Color schema: _S_erver, _C_lient, _I_ntegration (this script)

--- a/tests/server/run_integration.sh
+++ b/tests/server/run_integration.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+
+#
+# Configuration
+#
+
+
+# Path is relative to the pth of the folder containing Vagrantfile
+TEST_PROGRAM=./launch_t_client.sh
+
+# set to --force to just kill the VM power after the test.
+# keep empty for gracefull shutdoen
+FORCE_VM_SHUTDOWN=--force
+
+
+#
+# t_client.rc
+#
+
+# Make sure we trigger sudo password before starting the background processed
+# they mess up stdin/stdout and make sudo print the password.
+# Does _not_ fail without sudo/root. This is left to t_client.sh
+try_sudo_command_or_root() {
+    ID=`id`
+    if expr "$ID" : "uid=0" >/dev/null ; then
+        print_log I "running as root. sudo not needed"
+    else
+        srcdir="${srcdir:-..}"
+        top_builddir="${top_builddir:-../..}"
+
+        if [ -r "${top_builddir}"/t_client.rc ] ; then
+            print_log I "sourcing ${top_builddir}/t_client.rc"
+            . "${top_builddir}"/t_client.rc
+        elif [ -r "${srcdir}"/t_client.rc ] ; then
+            print_log I "sourcing ${srcdir}/t_client.rc"
+            . "${srcdir}"/t_client.rc
+        else
+            print_log Iw "t_client.sh neither found at '${top_builddir}/t_client.rc' nor '"${srcdir}"/t_client.rc'"
+        fi
+
+        if [ -z "$RUN_SUDO" ] ; then
+            print_log Iw "RUN_SUDO not defined and not running as root. t_client.sh wil propably fail."
+        else
+            # We have to use sudo. Make sure that we (hopefully) do not have
+            # to ask the users password during the test. This is done to
+            # prevent timing issues, e.g. when the waits for openvpn to start.
+            "$RUN_SUDO" \true || print_log Iw "'$RUN_SUDO' failed"
+        fi
+    fi
+}
+
+
+
+#
+# Implementation
+#
+
+
+if [ $# -ne 1 ]; then
+    echo $0 vm_folder
+    exit -1
+fi
+
+
+VM_FOLDER=$1
+if [ ! -d  "$VM_FOLDER" ]; then
+    echo $0 vm_folder
+    echo "-- '${VM_FOLDER}' is no directory"
+    exit -1
+fi
+
+
+# result 99: test not run bc. server could not be started
+test_result=99
+
+start_vm() {
+  cd "${VM_FOLDER}"
+  vagrant halt
+  vagrant up
+  vagrant ssh -c '/scripts/sync_codebase.sh && /scripts/compile.sh'
+}
+
+# Start t_client when the server emitted a line containing ${START_TEST_ON}
+START_TEST_ON="Initialization Sequence Completed"
+
+# $1 : Source/Color schema: _S_erver, _C_lient, _I_ntegration (this script
+#         Iw: Warning
+# $2 : message
+colorize() {
+  local schema="$1"
+  local msg="$2"
+
+  local BLACK=$(tput setaf 0)
+  local RED=$(tput setaf 1)
+  local GREEN=$(tput setaf 2)
+  local YELLOW=$(tput setaf 3)
+  local LIME_YELLOW=$(tput setaf 190)
+  local POWDER_BLUE=$(tput setaf 153)
+  local BLUE=$(tput setaf 4)
+  local MAGENTA=$(tput setaf 5)
+  local CYAN=$(tput setaf 6)
+  local WHITE=$(tput setaf 7)
+  local BRIGHT=$(tput bold)
+  local NORMAL=$(tput sgr0)
+  local BLINK=$(tput blink)
+  local REVERSE=$(tput smso)
+  local UNDERLINE=$(tput smul)
+
+  local ERROR="$RED"
+
+  local color=""
+
+  case "$schema" in
+    "S")
+      color="${POWDER_BLUE}"
+    ;;
+    "C")
+      color="${YELLOW}"
+    ;;
+    "I")
+      color="${GREEN}"
+    ;;
+    "Iw")
+      color="${BRIGHT}${RED}"
+    ;;
+    *)
+      color="${NORMAL}"
+    ;;
+  esac
+
+  msg="${color}${msg}${NORMAL}"
+
+  msg=${msg/FATAL/${ERROR}FATAL${color}}
+  msg=${msg/FAIL/${ERROR}FAIL${color}}
+  echo $msg
+}
+
+# $1 : Source/Color schema: _S_erver, _C_lient, _I_ntegration (this script)
+# $2 : message (one line)
+print_log() {
+  local src="$1"
+  local line="$2"
+
+  # Remove non-ascii. Esp. remove CR/LF because they break the processing logic
+  # Remove leading and trailing spaces
+  local sanitized=$(echo "$line" | tr -cd '\40-\176' \
+                                 | sed -e 's/^[ ]+//' -e 's/[ ]+$//')
+  sanitized=$(colorize $src "$sanitized")
+
+  printf "%s:\t%s\n" "$src" "$sanitized"
+}
+
+
+
+# Run the test command defined in $TEST_PROGRAM and halt the VM afterwards
+run_test() {
+  echo Starting Client
+
+  #Important: run 'test | format' so that the exit code of test is not lost
+  $TEST_PROGRAM 2>&1 | while read client_line
+  do
+    print_log "C" "$client_line"
+  done
+
+  local result=${PIPESTATUS[0]}
+  vagrant halt ${FORCE_VM_SHUTDOWN}
+
+  return $result
+}
+
+try_sudo_command_or_root
+start_vm
+
+while read server_line
+do
+  # At least on MacOS this is needed (without it the code only prints LF,
+  # but no CR)
+  reset -I
+
+  print_log "S"  "$server_line"
+
+  if [[ "$server_line" == *$START_TEST_ON* ]] ; then
+      run_test &
+  fi
+done < <(vagrant ssh -c 'sudo /scripts/start_server.sh' &)
+
+echo "Waiting for all jobs to terminate ...."
+
+wait %run_test
+test_result=$?
+wait
+
+exit $test_result

--- a/tests/server/run_integration.sh
+++ b/tests/server/run_integration.sh
@@ -169,7 +169,7 @@ print_log() {
 
 # Run the test command defined in $TEST_PROGRAM and halt the VM afterwards
 run_test() {
-  echo Starting Client
+  print_log "I" "Starting Client"
 
   #Important: run 'test | format' so that the exit code of test is not lost
   $TEST_PROGRAM 2>&1 | while read client_line

--- a/tests/server/scripts/compile.sh
+++ b/tests/server/scripts/compile.sh
@@ -1,0 +1,6 @@
+# -*- mode: sh -*-
+# vi: set ft=sh :
+#!/bin/sh
+
+cd ~/openvpn && autoreconf -vi --force && ./configure && make clean && make -j3
+# optionally: make check

--- a/tests/server/scripts/start_server.sh
+++ b/tests/server/scripts/start_server.sh
@@ -1,0 +1,88 @@
+# -*- mode: sh -*-
+# vi: set ft=sh :
+#!/bin/bash
+
+#
+# - Expects the source to be located at "~/openvpn"
+# - Must be run as root
+# - Expects a t_client.rc to be present
+#
+
+cd ~vagrant/openvpn/tests
+
+# Look for t_client.rc in the same locations t_client.sh does
+
+srcdir="${srcdir:-.}"
+top_builddir="${top_builddir:-..}"
+if [ -r "${top_builddir}"/t_client.rc ] ; then
+    . "${top_builddir}"/t_client.rc
+elif [ -r "${srcdir}"/t_client.rc ] ; then
+    . "${srcdir}"/t_client.rc
+else
+    echo "$0: cannot find 't_client.rc' in build dir ('${top_builddir}')" >&2
+    echo "$0: or source directory ('${srcdir}'). SKIPPING TEST." >&2
+    exit 77
+fi
+
+CA_CERT="${CA_CERT:-${top_srcdir}/sample/sample-keys/ca.crt}"
+CLIENT_KEY="${CLIENT_KEY:-${top_srcdir}/sample/sample-keys/client.key}"
+CLIENT_CERT="${CLIENT_CERT:-${top_srcdir}/sample/sample-keys/client.crt}"
+
+VM_SERVER_KEY="${VM_SERVER_KEY:-${top_srcdir}/sample/sample-keys/server.key}"
+VM_SERVER_CERT="${VM_SERVER_CERT:-${top_srcdir}/sample/sample-keys/server.crt}"
+VM_SERVER_DH="${VM_SERVER_DH:-${top_srcdir}/sample/sample-keys//dh2048.pem}"
+
+
+assert_var_set() {
+  local varname="$1"
+  local value=
+  eval value=\$$varname
+
+  if [ -n "${value}" ]; then
+     echo " - $varname  := '${value}'"
+  else
+     echo "$varname not defined in 't_client.rc'. abort." >&2
+     exit 77
+  fi
+}
+
+assert_var_set CA_CERT
+assert_var_set VM_SERVER_KEY
+assert_var_set VM_SERVER_CERT
+assert_var_set VM_SERVER_DH
+assert_var_set VM_SERVER_NET
+assert_var_set VM_SERVER_MASK
+assert_var_set REMOTE_PORT
+
+
+OPENVPN="${top_builddir}/src/openvpn/openvpn"
+
+if [ ! -x "${OPENVPN}" ] ;  then
+    echo "openvpn not found at '${OPENVPN}'" >&2
+    exit 77
+fi
+
+SERVER="$VM_SERVER_NET $VM_SERVER_MASK"
+
+# Bind to all adresses
+LOCAL="0.0.0.0"
+
+CMD="\"${OPENVPN}\" \
+ --mode server \
+ --dev tun \
+ --tls-server \
+ --dh \"${VM_SERVER_DH}\" \
+ --ca \"${CA_CERT}\" \
+ --cert \"${VM_SERVER_CERT}\" \
+ --key \"${VM_SERVER_KEY}\" \
+ --server ${SERVER} \
+ --local  ${LOCAL} \
+ --port   ${REMOTE_PORT} \
+ --topology subnet \
+ --comp-lzo \
+ --management ${LOCAL} 7505 \
+ --verb 3 \
+"
+
+echo $CMD
+eval $CMD

--- a/tests/server/scripts/sync_codebase.sh
+++ b/tests/server/scripts/sync_codebase.sh
@@ -1,0 +1,6 @@
+# -*- mode: sh -*-
+# vi: set ft=sh :
+#!/bin/sh
+
+cd ~
+rsync -avd --no-o /openvpn .

--- a/tests/server/ubuntu_precise64/README.md
+++ b/tests/server/ubuntu_precise64/README.md
@@ -1,0 +1,9 @@
+OpenVPN testserver
+====================
+
+| VM Definition                        |
+|------------|-------------------------|
+| **Distro** | Ubuntu Precise Pangolin |
+| **Arch**   | x86_64                  |
+| **IPv4**   | 192.168.33.66           |
+| **IPv6**   | N/A                     |

--- a/tests/server/ubuntu_precise64/Vagrantfile
+++ b/tests/server/ubuntu_precise64/Vagrantfile
@@ -1,0 +1,37 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "hashicorp/precise64"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  #
+  # This IP is used in  t_client.rc (REMOTE_IP). Make sure that both are
+  # the same, if you want to use this Vagrant VM
+  config.vm.network "private_network", ip: "192.168.33.67", netmask: "24"
+
+  # Mount the source root under /openvpn.
+  # TODO: mount read-only
+  config.vm.synced_folder "../../..", "/openvpn"
+  config.vm.synced_folder "../scripts", "/scripts"
+
+  config.vm.provider "virtualbox" do |vb|
+     vb.memory = 1024
+     # for compiling; only works in 64 bit VMs
+     vb.cpus = 2
+     # Faster imports
+     vb.linked_clone = true if Vagrant::VERSION =~ /^1.8/
+  end
+
+   config.vm.provision "shell", inline: <<-SHELL
+
+sudo apt-get update
+sudo apt-get install  -y autoconf g++ make liblzo2-dev libpam0g-dev openssl libtool
+
+echo '/scripts/sync_codebase.sh && /scripts/compile.sh && sudo /scripts/start_server.sh' > ~vagrant/compile_and_run.sh
+chmod 755 ~vagrant/compile_and_run.sh
+chown vagrant:vagrant ~vagrant/compile_and_run.sh
+SHELL
+end

--- a/tests/server/ubuntu_precise64/launch_t_client.sh
+++ b/tests/server/ubuntu_precise64/launch_t_client.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cd ../..
+REMOTE_IP=192.168.33.67 ./t_client.sh

--- a/tests/server/ubuntu_trusty64/README.md
+++ b/tests/server/ubuntu_trusty64/README.md
@@ -1,0 +1,9 @@
+OpenVPN testserver
+====================
+
+| VM Definition                      |
+|------------|-----------------------|
+| **Distro** | Ubuntu Trusty Tahr    |
+| **Arch**   | x86_64                |
+| **IPv4**   | 192.168.33.66         |
+| **IPv6**   | N/A                   |

--- a/tests/server/ubuntu_trusty64/Vagrantfile
+++ b/tests/server/ubuntu_trusty64/Vagrantfile
@@ -1,0 +1,37 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "ubuntu/trusty64"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  #
+  # This IP is used in  t_client.rc (REMOTE_IP). Make sure that both are
+  # the same, if you want to use this Vagrant VM
+  config.vm.network "private_network", ip: "192.168.33.66", netmask: "24"
+
+  # Mount the source root under /openvpn.
+  # TODO: mount read-only
+  config.vm.synced_folder "../../..", "/openvpn"
+  config.vm.synced_folder "../scripts", "/scripts"
+
+  config.vm.provider "virtualbox" do |vb|
+     vb.memory = 1024
+     # for compiling; only works in 64 bit VMs
+     vb.cpus = 2
+     # Faster imports
+     vb.linked_clone = true if Vagrant::VERSION =~ /^1.8/
+  end
+
+   config.vm.provision "shell", inline: <<-SHELL
+
+sudo apt-get update
+sudo apt-get install  -y autoconf g++ make liblzo2-dev libpam0g-dev libssl-dev libtool
+
+echo '/scripts/sync_codebase.sh && /scripts/compile.sh && sudo /scripts/start_server.sh' > ~vagrant/compile_and_run.sh
+chmod 755 ~vagrant/compile_and_run.sh
+chown vagrant:vagrant ~vagrant/compile_and_run.sh
+SHELL
+end

--- a/tests/server/ubuntu_trusty64/launch_t_client.sh
+++ b/tests/server/ubuntu_trusty64/launch_t_client.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cd ../..
+REMOTE_IP=192.168.33.66 ./t_client.sh

--- a/tests/t_client.rc-sample
+++ b/tests/t_client.rc-sample
@@ -4,6 +4,9 @@
 #
 # (sample config, copy to t_client.rc and adapt to your environment)
 #
+# This script is also sourced by the example OpenVPN servers (Vagrant files).
+#
+# The example servers can be run for instant remote endpoints for t_client.sh
 #
 # define these - if empty, no tests will run
 #
@@ -21,9 +24,25 @@ else
 fi
 
 #
-# remote host (used as macro below)
+# Configuration for the test server started via vagrant
 #
-REMOTE=mytestserver
+VM_SERVER_KEY="${top_srcdir}/sample/sample-keys/server.key"
+VM_SERVER_CERT="${top_srcdir}/sample/sample-keys/server.crt"
+VM_SERVER_DH="${top_srcdir}/sample/sample-keys//dh2048.pem"
+
+#
+VM_SERVER_IP="10.8.0.1"
+# Passed as --server $VM_SERVER_NET $VM_SERVER_MASK
+VM_SERVER_NET="10.8.0.0"
+VM_SERVER_MASK="255.255.255.0"
+
+#
+# remote host (used as macro below and for the test server in the vm)
+# When the test server (Vagrant) is used, make sure that
+# the IP  equals the IP in Vagrantfile
+REMOTE_IP="192.168.33.67"
+REMOTE_PORT="51194"
+
 #
 # tests to run (list suffixes for config stanzas below)
 #
@@ -66,14 +85,14 @@ OPENVPN_BASE_P2P="..."
 #   specify IPv4+IPv6 addresses expected from server and ping targets
 #
 RUN_TITLE_1="testing tun/udp/ipv4+ipv6"
-OPENVPN_CONF_1="$OPENVPN_BASE_P2MP --dev tun --proto udp --remote $REMOTE --port 51194"
+OPENVPN_CONF_1="$OPENVPN_BASE_P2MP --dev tun --proto udp --remote ${REMOTE_IP} --port ${REMOTE_PORT}"
 PING4_HOSTS_1="10.100.50.1 10.100.0.1"
 PING6_HOSTS_1="2001:db8::1 2001:db8:a050::1"
 
 # Test 2: TCP / p2mp tun
 #
 RUN_TITLE_2="testing tun/tcp/ipv4+ipv6"
-OPENVPN_CONF_2="$OPENVPN_BASE_P2MP --dev tun --proto tcp --remote $REMOTE --port 51194"
+OPENVPN_CONF_2="$OPENVPN_BASE_P2MP --dev tun --proto tcp --remote ${REMOTE_IP} --port ${REMOTE_PORT}"
 PING4_HOSTS_2="10.100.51.1 10.100.0.1"
 PING6_HOSTS_2="2001:db8::1 2001:db8:a051::1"
 #

--- a/tests/unit_tests/openvpn/Makefile.am
+++ b/tests/unit_tests/openvpn/Makefile.am
@@ -1,6 +1,9 @@
 AUTOMAKE_OPTIONS = foreign
 
-check_PROGRAMS = argv_testdriver buffer_testdriver
+check_PROGRAMS = 
+if SUPPORT_LD_WRAP
+check_PROGRAMS += argv_testdriver buffer_testdriver
+endif
 
 if ENABLE_CRYPTO
 check_PROGRAMS += tls_crypt_testdriver
@@ -11,6 +14,7 @@ TESTS = $(check_PROGRAMS)
 openvpn_includedir = $(top_srcdir)/include
 openvpn_srcdir = $(top_srcdir)/src/openvpn
 compat_srcdir = $(top_srcdir)/src/compat
+
 
 argv_testdriver_CFLAGS  = @TEST_CFLAGS@ -I$(openvpn_srcdir) -I$(compat_srcdir) \
 	$(OPTIONAL_CRYPTO_CFLAGS)


### PR DESCRIPTION
This patch will add test servers to use with t_client.sh. This will make testing on different systems much easier. Bonus: testing on a laptop is a breeze by "one command integration tests".

_Example_

``` bash
./run_integration.sh ubuntu_precise64
# does the following
# - start an Ubuntu Precise VM
# - Copy your current source code to the VM
# - configure & make on the VM
# - Run the server on the VM
# - Run t_client.sh *with the REMOTE_HOST pointing to the VM*
# - The outputs of client & server are colorized AND interleaved for better diagnosis
# - Tear down the server
```

Virtual machines are defined by [Vagrant](https://www.vagrantup.com) scripts. Virtualbox is used for virtualisation.

Each of the virtual machines is configured to compile openvpn and run a server.

Inside the vm a openvpn server can be launched to run `t_client.sh` tests against it. Sample launcher scripts are provided.

<img width="1280" alt="screen shot 2016-05-09 at 16 17 18" src="https://cloud.githubusercontent.com/assets/3842066/15127681/fddb7aa8-1637-11e6-9097-0f53f62c38ba.png">
