### PR TITLE
Reverted management_io to its original state to prevent the following problem:

### DIFF
--- a/src/openvpn/manage.c
+++ b/src/openvpn/manage.c
@@ -2787,7 +2787,7 @@ management_io (struct management *man)
 		  net_event_win32_clear_selected_events (&man->connection.ne32, FD_ACCEPT);
 		}
 	    }
-	  else if (man->connection.state == MS_CC_WAIT_READ || man->connection.state == MS_CC_WAIT_WRITE)
+	  else if (man->connection.state == MS_CC_WAIT_READ)
 	    {
 	      if (net_events & FD_READ)
 		{
@@ -2796,6 +2796,8 @@ management_io (struct management *man)
 		  net_event_win32_clear_selected_events (&man->connection.ne32, FD_READ);
 		}
 
+      if (man->connection.state == MS_CC_WAIT_WRITE)
+        {
 	      if (net_events & FD_WRITE)
 		{
 		  int status;
@@ -2805,6 +2807,7 @@ management_io (struct management *man)
 		      net_event_win32_clear_selected_events (&man->connection.ne32, FD_WRITE);
 		    }
 		}
+        }
 	    }
 	}
     }


### PR DESCRIPTION
man_read -> ... -> man_output_list_push_finalize -> management_io ->
man_read

After some digging I found this commit made by James Yonan in 2010:
https://sourceforge.net/p/openvpn/openvpn-testing/ci/3cf6c9328250061600b78c8a7deb0edc850e739b

In this commit he put both writing to and reading from the socket into the
same "if" branch, which leads to the problem I've mentioned above.
man_read after having been called recursively goes totally nuts and screws its input
buffer, as result, openvpn can processes the same command several times
and then fail to read the rest of them correctly.

I'm not sure that what I did here is the best way to solve this problem,
but it seems to work for me.