### PR TITLE
fix cppcheck findings

### DIFF
--- a/src/openvpn/error.c
+++ b/src/openvpn/error.c
@@ -728,15 +728,6 @@ msg_flags_string (const unsigned int flags, struct gc_arena *gc)
   return BSTR (&out);
 }
 
-#ifdef ENABLE_DEBUG
-void
-crash (void)
-{
-  char *null = NULL;
-  *null = 0;
-}
-#endif
-
 #ifdef WIN32
 
 const char *

--- a/src/openvpnserv/interactive.c
+++ b/src/openvpnserv/interactive.c
@@ -597,6 +597,7 @@ HandleAddressMessage (address_message_t *msg, undo_lists_t *lists)
         goto out;
 
       free (RemoveListItem (&(*lists)[address], CmpAddress, addr_row));
+      return err;
     }
 
 out:
@@ -696,6 +697,7 @@ HandleRouteMessage (route_message_t *msg, undo_lists_t *lists)
         goto out;
 
       free (RemoveListItem (&(*lists)[route], CmpRoute, fwd_row));
+      return err;
     }
 
 out:
@@ -1474,9 +1476,13 @@ UpdateWaitHandles (LPHANDLE *handles_ptr, LPDWORD count,
       if (pos == size)
         {
           size += 10;
-          handles = realloc (handles, size * sizeof (HANDLE));
-          if (handles == NULL)
-            return ERROR_OUTOFMEMORY;
+	  void * tmp = realloc (handles, size * sizeof (HANDLE));
+ 	  if (tmp == NULL)
+	  {
+		free(handles);
+		return ERROR_OUTOFMEMORY;
+	  }
+	  handles = tmp;
         }
       handles[pos++] = threads->data;
       threads = threads->next;


### PR DESCRIPTION
(both master and release/2.3)

[src/openvpn/error.c:736]: (error) Possible null pointer dereference: null
[src/openvpn/error.c:736]: (error) Null pointer dereference

function "crash" is not used anywhere. so, it's better to remove it.

(only master)

[src/openvpnserv/interactive.c:601]: (error) Memory pointed to by 'addr_row' is freed twice.
[src/openvpnserv/interactive.c:700]: (error) Memory pointed to by 'fwd_row' is freed twice.
[src/openvpnserv/interactive.c:1329]: (error) Common realloc mistake: 'handles' nulled but not freed upon failure

RemoveListItem free addr_row and fwd_row, so there's no need to free them once again after "goto". It is dirty fix, I'd say interactive.c is overcomplicated here (lots of "if"s and "goto"s), so it is better to rewrite it in some straightforward way.

as for realloc, it is common not to handle failures, it is not very dangerous, it is rather some sugar to stop cppcheck from noising.