### PR TITLE
 fix cppcheck findings

### DIFF
--- a/src/openvpn/error.c
+++ b/src/openvpn/error.c
@@ -702,15 +702,6 @@ msg_flags_string (const unsigned int flags, struct gc_arena *gc)
   return BSTR (&out);
 }
 
-#ifdef ENABLE_DEBUG
-void
-crash (void)
-{
-  char *null = NULL;
-  *null = 0;
-}
-#endif
-
 #ifdef WIN32
 
 const char *


### PR DESCRIPTION
[src/openvpn/error.c:736]: (error) Possible null pointer dereference: null
[src/openvpn/error.c:736]: (error) Null pointer dereference

function "crash" is not used anywhere. so, it's better to remove it.