### PR TITLE
Add an option to filter options received from server

### DIFF
--- a/Changes.rst
+++ b/Changes.rst
@@ -5,6 +5,10 @@ Version 2.4.0
 New features
 ------------
 
+pull-filter
+    New option to explicitly allow or reject options pushed by the server.
+    May be used multiple times and is applied in the order specified.
+
 push-remove
     new option to remove options on a per-client basis from the "push" list
     (more fine-grained than "push-reset")

--- a/doc/openvpn.8
+++ b/doc/openvpn.8
@@ -3830,6 +3830,32 @@ in situations where you don't trust the server to have control
 over the client's routing table.
 .\"*********************************************************
 .TP
+.B \-\-pull\-filter accept|reject opt
+Filter options matching
+.B opt
+pushed by the server:
+.B accept
+allows the option,
+.B reject
+removes it. May be specified multiple times, and each filter is
+applied in the order it is specified. The filtering of each pushed
+option stops as soon as a match (accept or reject) is found.
+
+Partial matching is used so that
+.B \-\-pull\-filter reject route
+would remove all pushed options starting with
+.B route
+which would include, for example,
+.B route\-gateway.
+.B \-\-pull\-filter accept "route 192.168.1."
+followed by
+.B \-\-pull\-filter reject "route "
+would reject all pushed routes that do not start with
+.B 192.168.1.
+
+May be used only on clients.
+.\"*********************************************************
+.TP
 .B \-\-auth\-user\-pass [up]
 Authenticate with server using username/password.
 .B up

--- a/src/openvpn/options.h
+++ b/src/openvpn/options.h
@@ -163,6 +163,23 @@ struct remote_host_store
   char port[RH_PORT_LEN];
 };
 
+#define PULL_FILTER_LIST_SIZE 64
+struct pull_filter
+{
+# define PUF_TYPE_UNDEF 0
+# define PUF_TYPE_ACCEPT 1
+# define PUF_TYPE_REJECT 2
+  int type;
+  int size;
+  char *filter;
+};
+
+struct pull_filter_list
+{
+  int len;
+  struct pull_filter *array[PULL_FILTER_LIST_SIZE];
+};
+
 /* Command line options */
 struct options
 {
@@ -597,6 +614,8 @@ struct options
   const char *keying_material_exporter_label;
   int keying_material_exporter_length;
 #endif
+
+  struct pull_filter_list *pull_filter_list;
 };
 
 #define streq(x, y) (!strcmp((x), (y)))


### PR DESCRIPTION
Usage: --pull-filter accept|reject "option string"

Permit a client to selectively accept or reject options pushed
by the server. May be used multiple times. The filters are
applied in the order specified to each pushed option received. The
filtering stops as soon as a match is found. Full regex support is
not available but partial matching provides some flexibility. Thus

  pull-filter accept "ifconfig 10.9.0."
  pull-filter reject "ifconfig "
  pull-filter accept "route 10."
  pull-filter reject "route "

will reject assigned ip unless its in the "10.9.0.0/24" range and
all pushed routes except those starting with "10.". Note the space
at the end of "route " to not reject "route-gateway", for example.

There is an implicit 'pull-filter accept ""' at the end so that all
options not rejected by any filter are accepted.

Acknowledges shameless imitation of --push-remove.
Inspired by Trac #682.

Signed-off-by: Selva Nair <selva.nair@gmail.com>