### PR TITLE
fix cppcheck finding

### DIFF
--- a/src/openvpn/buffer.c
+++ b/src/openvpn/buffer.c
@@ -438,10 +438,12 @@ format_hex_ex (const uint8_t *data, int size, int maxoutput,
 	       unsigned int space_break_flags, const char* separator,
 	       struct gc_arena *gc)
 {
-  struct buffer out = alloc_buf_gc (maxoutput ? maxoutput :
+  int i;
+  struct buffer out;
+  ASSERT( maxoutput > 0 || separator != NULL );
+  out = alloc_buf_gc (maxoutput ? maxoutput :
 				    ((size * 2) + (size / (space_break_flags & FHE_SPACE_BREAK_MASK)) * (int) strlen (separator) + 2),
 				    gc);
-  int i;
   for (i = 0; i < size; ++i)
     {
       if (separator && i && !(i % (space_break_flags & FHE_SPACE_BREAK_MASK)))


### PR DESCRIPTION
[src/openvpn/buffer.c:442] -> [src/openvpn/buffer.c:447]: (warning) Either the condition 'if(separator&&i&&!(i%(space_break_flags&255)))' is redundant or there is possible null pointer dereference: separator.
[src/openvpn/buffer.c:443] -> [src/openvpn/buffer.c:447]: (warning) Either the condition 'if(separator&&i&&!(i%(space_break_flags&255)))' is redundant or there is possible null pointer dereference: separator.
