### PR TITLE
crypto: Add the --ca-pkcs11-id option

### DIFF
--- a/doc/openvpn.8
+++ b/doc/openvpn.8
@@ -4620,6 +4620,13 @@ by the standalone
 option.
 .\"*********************************************************
 .TP
+.B \-\-ca\-pkcs11\-id name
+Specify the serialized object id of a x509 CA certificate instead of a file
+certificate set with
+.B \-\-ca
+option.
+.\"*********************************************************
+.TP
 .B \-\-pkcs11\-id\-management
 Acquire PKCS#11 id from management interface. In this case a NEED-STR 'pkcs11-id-request'
 real-time message will be triggered, application may use pkcs11-id-count command to

--- a/src/openvpn/options.h
+++ b/src/openvpn/options.h
@@ -525,6 +525,7 @@ struct options
   bool pkcs11_protected_authentication[MAX_PARMS];
   bool pkcs11_cert_private[MAX_PARMS];
   int pkcs11_pin_cache_period;
+  const char *ca_pkcs11_id;
   const char *pkcs11_id;
   bool pkcs11_id_management;
 #endif

--- a/src/openvpn/pkcs11.h
+++ b/src/openvpn/pkcs11.h
@@ -63,7 +63,9 @@ int
 tls_ctx_use_pkcs11 (
 	struct tls_root_ctx * const ssl_ctx,
 	bool pkcs11_id_management,
-	const char * const pkcs11_id
+	const char * const pkcs11_id,
+	const char * const ca_pkcs11_id,
+	bool tls_server
 );
 
 void

--- a/src/openvpn/pkcs11_backend.h
+++ b/src/openvpn/pkcs11_backend.h
@@ -64,12 +64,16 @@ int pkcs11_certificate_serial (pkcs11h_certificate_t certificate, char *serial,
  * Load PKCS #11 Certificate's information into the given TLS context
  *
  * @param certificate 	The PKCS #11 helper certificate object
+ * @param ca	 	The PKCS #11 helper CA object
  * @param ssl_ctx	TLS context to use.
+ * @tls_server		True if we need to set the CA name list for the client
  *
  * @return 		1 on failure, 0 on success
  */
 int pkcs11_init_tls_session(pkcs11h_certificate_t certificate,
-    struct tls_root_ctx * const ssl_ctx);
+    pkcs11h_certificate_t ca,
+    struct tls_root_ctx * const ssl_ctx,
+    bool tls_server);
 
 #endif /* defined(ENABLE_PKCS11) */
 #endif /* PKCS11_BACKEND_H_ */

--- a/src/openvpn/pkcs11_mbedtls.c
+++ b/src/openvpn/pkcs11_mbedtls.c
@@ -44,11 +44,18 @@
 
 int
 pkcs11_init_tls_session(pkcs11h_certificate_t certificate,
-    struct tls_root_ctx * const ssl_ctx)
+    pkcs11h_certificate_t ca,
+    struct tls_root_ctx * const ssl_ctx,
+    bool tls_server)
 {
   int ret = 1;
 
   ASSERT (NULL != ssl_ctx);
+
+  if (ca) {
+      msg (M_FATAL, "PKCS#11: CA on PKCS#11 not supported with mbed TLS");
+      goto cleanup;
+  }
 
   ALLOC_OBJ_CLEAR (ssl_ctx->crt_chain, mbedtls_x509_crt);
   if (mbedtls_pkcs11_x509_cert_bind(ssl_ctx->crt_chain, certificate)) {

--- a/src/openvpn/ssl.c
+++ b/src/openvpn/ssl.c
@@ -525,10 +525,10 @@ init_ssl (const struct options *options, struct tls_root_ctx *new_ctx)
 #ifdef ENABLE_PKCS11
   else if (options->pkcs11_providers[0])
     {
-      if (!tls_ctx_use_pkcs11 (new_ctx, options->pkcs11_id_management, options->pkcs11_id))
+      if (!tls_ctx_use_pkcs11 (new_ctx, options->pkcs11_id_management, options->pkcs11_id,
+	    options->ca_pkcs11_id, options->tls_server))
 	{
-	  msg (M_WARN, "Cannot load certificate \"%s\" using PKCS#11 interface",
-	      options->pkcs11_id);
+	  msg (M_WARN, "Cannot initialize PKCS#11 interface");
 	  goto err;
 	}
     }


### PR DESCRIPTION
Hi,

We're working on integrating NetworkManager with p11-kit's PKCS#11 remoting to allow using PKCS#11 with user initiated VPN (and Wi-Fi) connections: https://bugzilla.gnome.org/show_bug.cgi?id=767872

Currently OpenVPN seems to do pretty well with PKCS#11. That is, with an exception of CA handling. Users tend to need to supply their CA certificate and place it in their home directory. We'd like to use PKCS#11 instead because then we could avoid letting the VPN daemon being able to access files user's home directly (SELinux is already really unhappy about this) and would be able to use a nice certificate picker. Integration with smart cards would then be easier too.

I'm wondering if this and the patch makes sense to you, before I post it to the list.

Thank you,
Lubo
