### PR TITLE
Deprecate the automatic part of openvpnserv.exe

### DIFF
--- a/src/openvpnserv/automatic.c
+++ b/src/openvpnserv/automatic.c
@@ -49,8 +49,8 @@ static SERVICE_STATUS status;
 
 openvpn_service_t automatic_service = {
   automatic,
-  TEXT(PACKAGE_NAME "Service"),
-  TEXT(PACKAGE_NAME " Service"),
+  TEXT(PACKAGE_NAME "ServiceLegacy"),
+  TEXT(PACKAGE_NAME " Legacy Service"),
   TEXT(SERVICE_DEPENDENCIES),
   SERVICE_DEMAND_START
 };


### PR DESCRIPTION
The automatic part will be replaced by openvpnserv.exe, a significantly improved
service wrapper written in C#.

Signed-off-by: Samuli Seppänen <samuli@openvpn.net>