### PR TITLE
netconfig: Add support for configuring tun/tap interface in a Linux network namespace (netns)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -428,7 +428,7 @@ AC_CHECK_HEADERS([ \
 	ctype.h sys/types.h sys/socket.h \
 	signal.h unistd.h dlfcn.h \
 	netinet/in.h netinet/in_systm.h \
-	netinet/tcp.h arpa/inet.h netdb.h \
+	netinet/tcp.h arpa/inet.h netdb.h sched.h \
 	windows.h winsock2.h ws2tcpip.h \
 	versionhelpers.h \
 ])
@@ -655,7 +655,7 @@ AC_CHECK_FUNCS([ \
 	ctime memset vsnprintf strdup \
 	setsid chdir putenv getpeername unlink \
 	chsize ftruncate execve getpeereid umask basename dirname access \
-	epoll_create strsep \
+	epoll_create strsep setns \
 ])
 
 AC_CHECK_LIB(

--- a/doc/openvpn.8
+++ b/doc/openvpn.8
@@ -745,6 +745,12 @@ or
 .B tap.
 .\"*********************************************************
 .TP
+.B \-\-dev\-netns path
+Configure the device in the Linux network namespace bound to the specified
+.B path,
+such as /run/netns/NAME or /proc/PID/ns/net
+.\"*********************************************************
+.TP
 .B \-\-topology mode
 Configure virtual addressing topology when running in
 .B \-\-dev tun

--- a/src/openvpn/openvpn.h
+++ b/src/openvpn/openvpn.h
@@ -541,6 +541,8 @@ struct context
     struct context_0 *c0;       /**< Level 0 %context. */
     struct context_1 c1;        /**< Level 1 %context. */
     struct context_2 c2;        /**< Level 2 %context. */
+
+    int parent_netns;
 };
 
 /*

--- a/src/openvpn/options.c
+++ b/src/openvpn/options.c
@@ -176,6 +176,10 @@ static const char usage_message[] =
     "                  does not begin with \"tun\" or \"tap\".\n"
     "--dev-node node : Explicitly set the device node rather than using\n"
     "                  /dev/net/tun, /dev/tun, /dev/tap, etc.\n"
+#ifdef HAVE_SETNS
+  "--dev-netns path: Configure the device in the Linux network namespace bound\n"
+  "                  to path, such as '/run/netns/NAME' or '/proc/PID/ns/net'.\n"
+#endif
     "--lladdr hw     : Set the link layer address of the tap device.\n"
     "--topology t    : Set --dev tun topology: 'net30', 'p2p', or 'subnet'.\n"
 #ifdef ENABLE_IPROUTE
@@ -1571,6 +1575,7 @@ show_settings(const struct options *o)
     SHOW_STR(dev);
     SHOW_STR(dev_type);
     SHOW_STR(dev_node);
+    SHOW_STR(dev_netns);
     SHOW_STR(lladdr);
     SHOW_INT(topology);
     SHOW_STR(ifconfig_local);
@@ -5380,6 +5385,11 @@ add_option(struct options *options,
     {
         VERIFY_PERMISSION(OPT_P_GENERAL);
         options->dev_node = p[1];
+    }
+    else if (streq (p[0], "dev-netns") && p[1] && !p[2])
+    {
+        VERIFY_PERMISSION(OPT_P_GENERAL);
+        options->dev_netns = p[1];
     }
     else if (streq(p[0], "lladdr") && p[1] && !p[2])
     {

--- a/src/openvpn/options.h
+++ b/src/openvpn/options.h
@@ -247,6 +247,7 @@ struct options
     const char *dev;
     const char *dev_type;
     const char *dev_node;
+    const char *dev_netns;
     const char *lladdr;
     int topology; /* one of the TOP_x values from proto.h */
     const char *ifconfig_local;

--- a/src/openvpn/route.c
+++ b/src/openvpn/route.c
@@ -997,22 +997,13 @@ redirect_default_route_to_vpn(struct route_list *rl, const struct tuntap *tt,
         {
             msg(M_WARN, "%s VPN gateway parameter (--route-gateway or --ifconfig) is missing", err);
         }
-        /*
-         * check if a default route is defined, unless:
-         * - we are connecting to a remote host in our network
-         * - we are connecting to a non-IPv4 remote host (i.e. we use IPv6)
-         */
-        else if (!(rl->rgi.flags & RGI_ADDR_DEFINED) && !local
-                 && (rl->spec.remote_host != IPV4_INVALID_ADDR))
-        {
-            msg(M_WARN, "%s Cannot read current default gateway from system", err);
-        }
         else if (!(rl->spec.flags & RTSA_REMOTE_HOST))
         {
             msg(M_WARN, "%s Cannot obtain current remote host address", err);
         }
         else
         {
+            bool orig_gateway = rl->rgi.flags & RGI_ADDR_DEFINED;
 #ifndef TARGET_ANDROID
             if (rl->flags & RG_AUTO_LOCAL)
             {
@@ -1028,7 +1019,7 @@ redirect_default_route_to_vpn(struct route_list *rl, const struct tuntap *tt,
                     local = true;
                 }
             }
-            if (!local)
+            if (orig_gateway && !local)
             {
                 /* route remote host to original default gateway */
                 /* if remote_host is not ipv4 (ie: ipv6), just skip
@@ -1052,13 +1043,16 @@ redirect_default_route_to_vpn(struct route_list *rl, const struct tuntap *tt,
             }
 #endif /* ifndef TARGET_ANDROID */
 
-            /* route DHCP/DNS server traffic through original default gateway */
-            add_bypass_routes(&rl->spec.bypass, rl->rgi.gateway.addr, tt, flags,
-                              &rl->rgi, es, ctx);
+            if (orig_gateway)
+            {
+                /* route DHCP/DNS server traffic through original default gateway */
+                add_bypass_routes(&rl->spec.bypass, rl->rgi.gateway.addr, tt, flags,
+                                  &rl->rgi, es, ctx);
+            }
 
             if (rl->flags & RG_REROUTE_GW)
             {
-                if (rl->flags & RG_DEF1)
+                if (orig_gateway && rl->flags & RG_DEF1)
                 {
                     /* add new default route (1st component) */
                     add_route3(0x00000000,
@@ -1116,6 +1110,8 @@ undo_redirect_default_route_to_vpn(struct route_list *rl,
 {
     if (rl && rl->iflags & RL_DID_REDIRECT_DEFAULT_GATEWAY)
     {
+        bool orig_gateway = rl->rgi.flags & RGI_ADDR_DEFINED;
+
         /* delete remote host route */
         if (rl->iflags & RL_DID_LOCAL)
         {
@@ -1130,13 +1126,16 @@ undo_redirect_default_route_to_vpn(struct route_list *rl,
             rl->iflags &= ~RL_DID_LOCAL;
         }
 
-        /* delete special DHCP/DNS bypass route */
-        del_bypass_routes(&rl->spec.bypass, rl->rgi.gateway.addr, tt, flags,
-                          &rl->rgi, es, ctx);
+        if (orig_gateway)
+        {
+            /* delete special DHCP/DNS bypass route */
+            del_bypass_routes(&rl->spec.bypass, rl->rgi.gateway.addr, tt, flags,
+                              &rl->rgi, es, ctx);
+        }
 
         if (rl->flags & RG_REROUTE_GW)
         {
-            if (rl->flags & RG_DEF1)
+            if (orig_gateway && rl->flags & RG_DEF1)
             {
                 /* delete default route (1st component) */
                 del_route3(0x00000000,

--- a/src/openvpn/syshead.h
+++ b/src/openvpn/syshead.h
@@ -244,6 +244,10 @@
 #include <netinet/tcp.h>
 #endif
 
+#ifdef HAVE_SCHED_H
+#include <sched.h>
+#endif
+
 #endif /* TARGET_LINUX */
 
 #ifdef TARGET_SOLARIS


### PR DESCRIPTION
This was submitted to openvpn-users@lists.sourceforge.net, but was not discussed.

---

I would like a Linux system using OpenVPN client to support:
1. Running applications that have network access via OpenVPN tun/tap interface, but no network access via the underlying interface (when OpenVPN interface goes down for any reason and brings down its routes).
2. Running applications that have network access only via the underlying interface, even when OpenVPN tun/tap interface is up.
3. Chaining OpenVPN clients (tunnel in tunnel).

All this is easily achievable with the help of Linux network namespaces: one just needs to run OpenVPN in the namespace with the underlying interface, but configure tun/tap in another namespace.  Then applications in the first namespace will not see OpenVPN at all, and applications in the second namespace will not see the underlying interface; and to chain OpenVPN clients, one just runs the second client in the second namespace with its tun/tap in the third one, and so on.

Here is an almost complete implementation of this idea.  The only thing missing is that `redirect_default_route_to_vpn()` fails because it "Cannot read current default gateway from system" and I am not sure about the proper fix.  (It should just set the new gateway as the default.)

To use OpenVPN with namespaces, just add some, and specify `--dev-netns` option. Assuming VPN server provides internet access:

``` sh
ip netns add abc
openvpn --config CONFIF --dev-netns /run/netns/abc
# List routes.
ip -n abc route
# Add default, as long as redirect_default_route_to_vpn() cannot do it.
ip -n abc route add default via XXX
ip netns exec abc ping 8.8.8.8
```

---

I am aware of http://www.naju.se/articles/openvpn-netns and http://www.naju.se/articles/openvpn-netns, but these scripts are very ad-hoc and fragile, e.g. they do not support buth tun and tap devices, and their only purpose is to reimplement what `do_open_tun()` does after the kernel wipes all its work when the interface is moved into another namespace.
