### PR TITLE
Add --outer-vrf option.

### DIFF
--- a/src/openvpn/init.c
+++ b/src/openvpn/init.c
@@ -2856,7 +2856,8 @@ do_init_socket_1 (struct context *c, const int mode)
 			   c->options.sndbuf,
 			   c->options.mark,
 			   &c->c2.server_poll_interval,
-			   sockflags);
+			   sockflags,
+			   c->options.outer_vrf);
 }
 
 /*

--- a/src/openvpn/options.c
+++ b/src/openvpn/options.c
@@ -167,6 +167,8 @@ static const char usage_message[] =
                    " or --socks-proxy"
                    " is used).\n"
   "--nobind        : Do not bind to local address and port.\n"
+  "--outer-vrf vrf : Bind to the given VRF when making connection to a peer/\n"
+  "                  listening for connections. (Linux only)\n"
   "--dev tunX|tapX : tun/tap device (X can be omitted for dynamic device.\n"
   "--dev-type dt   : Which device type are we using? (dt = tun or tap) Use\n"
   "                  this option only if the tun/tap device used with --dev\n"
@@ -5128,6 +5130,13 @@ add_option (struct options *options,
 	    msg (msglevel, "unknown socket flag: %s", p[j]);	    
 	}
     }
+#ifdef TARGET_LINUX
+  else if (streq (p[0], "outer-vrf") && p[1])
+    {
+      VERIFY_PERMISSION (OPT_P_SOCKFLAGS);
+      options->outer_vrf = p[1];
+    }
+#endif
   else if (streq (p[0], "txqueuelen") && p[1] && !p[2])
     {
       VERIFY_PERMISSION (OPT_P_GENERAL);

--- a/src/openvpn/options.h
+++ b/src/openvpn/options.h
@@ -325,6 +325,7 @@ struct options
 
   /* socket flags */
   unsigned int sockflags;
+  char *outer_vrf;
 
   /* route management */
   const char *route_script;

--- a/src/openvpn/socket.c
+++ b/src/openvpn/socket.c
@@ -868,6 +868,13 @@ create_socket (struct link_socket* sock, struct addrinfo* addr)
     /* set socket to --mark packets with given value */
     socket_set_mark (sock->sd, sock->mark);
 
+#ifdef TARGET_LINUX
+  if (sock->outer_vrf)
+    {
+      setsockopt (sock->sd, SOL_SOCKET, SO_BINDTODEVICE, sock->outer_vrf, strlen (sock->outer_vrf) + 1);
+    }
+#endif
+
     bind_local (sock, addr->ai_family);
 }
 
@@ -1525,7 +1532,8 @@ link_socket_init_phase1 (struct link_socket *sock,
 			 int sndbuf,
 			 int mark,
 			 struct event_timeout* server_poll_timeout,
-			 unsigned int sockflags)
+			 unsigned int sockflags,
+			 const char *outer_vrf)
 {
   ASSERT (sock);
 
@@ -1550,6 +1558,7 @@ link_socket_init_phase1 (struct link_socket *sock,
 
   sock->sockflags = sockflags;
   sock->mark = mark;
+  sock->outer_vrf = outer_vrf;
 
   sock->info.proto = proto;
   sock->info.af = af;

--- a/src/openvpn/socket.h
+++ b/src/openvpn/socket.h
@@ -213,6 +213,7 @@ struct link_socket
 # define SF_GETADDRINFO_DGRAM (1<<4)
   unsigned int sockflags;
   int mark;
+  char *outer_vrf;
 
   /* for stream sockets */
   struct stream_buf stream_buf;
@@ -327,7 +328,8 @@ link_socket_init_phase1 (struct link_socket *sock,
 			 int sndbuf,
 			 int mark,
 			 struct event_timeout* server_poll_timeout,
-			 unsigned int sockflags);
+			 unsigned int sockflags,
+			 const char *outer_vrf);
 
 void link_socket_init_phase2 (struct link_socket *sock,
 			      const struct frame *frame,


### PR DESCRIPTION
  This options allows the user to specify the Linux VRF[0] the OpenVPN process
  should use when making a connection or binding to an address.

  This allows making connections using the non-default VRF and having the tun/
  tap interface in the default VRF.

  [0] https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/networking/vrf.txt

Signed-off-by: Maximilian Wilhelm <max@rfc2324.org>