### PR TITLE
allow to enable plugin lookup with configure argument

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -303,7 +303,7 @@ AC_ARG_WITH(
 
 AC_ARG_WITH(
 	[plugindir],
-	[AS_HELP_STRING([--with-plugindir], [plugin directory @<:@default=LIBDIR/openvpn@:>@])],
+	[AS_HELP_STRING([--with-plugindir], [plugin directory @<:@default=LIBDIR/openvpn/plugins@:>@])],
 	,
 	[with_plugindir="\$(libdir)/openvpn/plugins"]
 )

--- a/configure.ac
+++ b/configure.ac
@@ -308,6 +308,14 @@ AC_ARG_WITH(
 	[with_plugindir="\$(libdir)/openvpn/plugins"]
 )
 
+AC_ARG_ENABLE(
+	[plugin-lookup],
+	[AS_HELP_STRING([--enable-plugin-lookup], [enable plugin lookup in plugin directory @<:@default=no@:>@])],
+	[enable_plugin_lookup="$enableval"],
+	[enable_plugin_lookup="no"]
+)
+AM_CONDITIONAL([ENABLE_PLUGIN_LOOKUP], [test x$enable_plugin_lookup = xyes])
+
 
 AC_DEFINE_UNQUOTED([TARGET_ALIAS], ["${host}"], [A string representing our host])
 case "$host" in

--- a/src/openvpn/Makefile.am
+++ b/src/openvpn/Makefile.am
@@ -33,6 +33,10 @@ if WIN32
 AM_CFLAGS += -municode -UUNICODE
 endif
 
+if ENABLE_PLUGIN_LOOKUP
+AM_CFLAGS += -DPLUGIN_LIBDIR=\"$(plugindir)\"
+endif
+
 sbin_PROGRAMS = openvpn
 
 openvpn_SOURCES = \


### PR DESCRIPTION
For plugin lookup (give relative path to plugin directory in configuration) we had to configure with something like this:
```
CFLAGS="$CFLAGS -DPLUGIN_LIBDIR=\\\"/usr/lib/openvpn/plugins\\\"" ./configure
```
This allows to pass `--enable-plugin-lookup` to configure to achieve the same. As a bonus we can be sure that install path and lookup path in openvpn binary are the same.