### PR TITLE
options: Remove IPv6 netmask limitation.

### DIFF
--- a/src/openvpn/options.c
+++ b/src/openvpn/options.c
@@ -4730,12 +4730,6 @@ add_option (struct options *options,
       if ( get_ipv6_addr( p[1], NULL, &netbits, msglevel ) &&
            ipv6_addr_safe( p[2] ) )
         {
-	  if ( netbits < 64 || netbits > 124 )
-	    {
-	      msg( msglevel, "ifconfig-ipv6: /netbits must be between 64 and 124, not '/%d'", netbits );
-	      goto err;
-	    }
-
 	  options->ifconfig_ipv6_local = get_ipv6_addr_no_netbits (p[1], &options->gc);
 	  options->ifconfig_ipv6_netbits = netbits;
 	  options->ifconfig_ipv6_remote = p[2];


### PR DESCRIPTION
Hello,

I found that OpenVPN is refusing to configure an IPv6 netmask of less than 64 bits, or more than 124 bits.

This occurred to me in two different specific cases, one with a /128 netmask and another with a /56 netmask, when integrating OpenVPN into an already existing layer 3 network, where creating new subnets was not an option at all.

I had to workaround this apparently artificial limitation with `--iroute` on the servers, and a custom `--up` script on the clients. Then things started working as expected.

Maybe this check makes sense on Windows due to the many limitations of its network stack? But I think it definitely does not make sense on Linux.

So I'm proposing to remove this check.

What do you think?

Cheers,
Vittorio