### PR TITLE
Implement the passtos option for IPv6 packets and sockets.

### DIFF
--- a/src/openvpn/forward.h
+++ b/src/openvpn/forward.h
@@ -247,7 +247,7 @@ void process_outgoing_tun (struct context *c);
 
 bool send_control_channel_string (struct context *c, const char *str, int msglevel);
 
-#define PIPV4_PASSTOS         (1<<0)
+#define PIP_PASSTOS           (1<<0)
 #define PIP_MSSFIX            (1<<1)         /* v4 and v6 */
 #define PIPV4_OUTGOING        (1<<2)
 #define PIPV4_EXTRACT_DHCP_ROUTER (1<<3)

--- a/src/openvpn/multi.c
+++ b/src/openvpn/multi.c
@@ -2697,7 +2697,7 @@ multi_get_queue (struct mbuf_set *ms)
 
   if (mbuf_extract_item (ms, &item)) /* cleartext IP packet */
     {
-      unsigned int pip_flags = PIPV4_PASSTOS;
+      unsigned int pip_flags = PIP_PASSTOS;
 
       set_prefix (item.instance);
       item.instance->context.c2.buf = item.buffer->buf;

--- a/src/openvpn/options.c
+++ b/src/openvpn/options.c
@@ -262,7 +262,7 @@ static const char usage_message[] =
   "--persist-local-ip  : Keep local IP address across SIGUSR1 or --ping-restart.\n"
   "--persist-key   : Don't re-read key files across SIGUSR1 or --ping-restart.\n"
 #if PASSTOS_CAPABILITY
-  "--passtos       : TOS passthrough (applies to IPv4 only).\n"
+  "--passtos       : TOS passthrough.\n"
 #endif
   "--tun-mtu n     : Take the tun/tap device MTU to be n and derive the\n"
   "                  TCP/UDP MTU from it (default=%d).\n"

--- a/src/openvpn/options.h
+++ b/src/openvpn/options.h
@@ -263,7 +263,7 @@ struct options
   bool persist_key;             /* Don't re-read key files on SIGUSR1 or PING_RESTART */
 
 #if PASSTOS_CAPABILITY
-  bool passtos;                  
+  bool passtos;
 #endif
 
   int resolve_retry_seconds;    /* If hostname resolve fails, retry for n seconds */

--- a/src/openvpn/syshead.h
+++ b/src/openvpn/syshead.h
@@ -396,7 +396,7 @@
 /*
  * Do we have the capability to support the --passtos option?
  */
-#if defined(IPPROTO_IP) && defined(IP_TOS) && defined(HAVE_SETSOCKOPT)
+#if defined(IPPROTO_IP) && defined(IP_TOS) && defined(IPPROTO_IPV6) && defined(IPV6_TCLASS) && defined(HAVE_SETSOCKOPT)
 #define PASSTOS_CAPABILITY 1
 #else
 #define PASSTOS_CAPABILITY 0


### PR DESCRIPTION
Hello,

This pull request implements the `passtos` option for both IPv6 packets (parsing the ToS of IPv6 packets received inside the tunnel) and sockets (setting the ToS of IPv6 encrypted packets sent to the OpenVPN server).

Cheers,
Vittorio