### PR TITLE
Run tests needing 'ld --wrap' only where supported

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -309,11 +309,17 @@ AC_ARG_WITH(
 )
 
 
+# Test if ld supports '--wrap' whcih currently is only supported on Linux
+# http://www.mockator.com/projects/mockator/wiki/Wrap_Functions
+AM_CONDITIONAL([SUPPORT_LD_WRAP], [ false ])
+
 AC_DEFINE_UNQUOTED([TARGET_ALIAS], ["${host}"], [A string representing our host])
 case "$host" in
 	*-*-linux*)
 		AC_DEFINE([TARGET_LINUX], [1], [Are we running on Linux?])
 		AC_DEFINE_UNQUOTED([TARGET_PREFIX], ["L"], [Target prefix])
+                # It might be better to actually run ld with --wrap
+                AM_CONDITIONAL([SUPPORT_LD_WRAP], [ true ])
 		;;
 	*-*-solaris*)
 		AC_DEFINE([TARGET_SOLARIS], [1], [Are we running on Solaris?])

--- a/tests/unit_tests/openvpn/Makefile.am
+++ b/tests/unit_tests/openvpn/Makefile.am
@@ -1,6 +1,9 @@
 AUTOMAKE_OPTIONS = foreign
 
-check_PROGRAMS = argv_testdriver buffer_testdriver
+check_PROGRAMS = 
+if SUPPORT_LD_WRAP
+check_PROGRAMS += argv_testdriver buffer_testdriver
+endif
 
 if ENABLE_CRYPTO
 check_PROGRAMS += tls_crypt_testdriver
@@ -11,6 +14,7 @@ TESTS = $(check_PROGRAMS)
 openvpn_includedir = $(top_srcdir)/include
 openvpn_srcdir = $(top_srcdir)/src/openvpn
 compat_srcdir = $(top_srcdir)/src/compat
+
 
 argv_testdriver_CFLAGS  = @TEST_CFLAGS@ -I$(openvpn_srcdir) -I$(compat_srcdir) \
 	$(OPTIONAL_CRYPTO_CFLAGS)


### PR DESCRIPTION
    Run tests needing 'ld --wrap' only where supported

    --wrap is a feature of ld that is only available on Linux systems.
    http://www.mockator.com/projects/mockator/wiki/Wrap_Functions

    "Alas, this feature is *only available with the GNU tool chain on Linux*.
    GCC for Mac OS X does not offer the linker flag --wrap. "

    The implementation is still not optimal. Improvement would be an actual
    check against running with '--wrap'.

    Tested on Ubuntu precise (--wrap tests run) && Macos (--wrap tests not run).