### PR TITLE
Close stdout/stderr/stdin fds in auth-plugin fork

### DIFF
--- a/src/plugins/auth-pam/auth-pam.c
+++ b/src/plugins/auth-pam/auth-pam.c
@@ -239,6 +239,21 @@ close_fds_except(int keep)
             close(i);
         }
     }
+
+#if defined(HAVE_DUP) && defined(HAVE_DUP2)
+    int fd;
+    if ((fd = open ("/dev/null", O_RDWR, 0)) != -1)
+    {
+        dup2 (fd, 0);
+        dup2 (fd, 1);
+        dup2 (fd, 2);
+        if (fd > 2)
+        {
+            close (fd);
+        }
+    }
+#endif
+
 }
 
 /*


### PR DESCRIPTION
The auth-pam plugin gets forked to run in background and kept
stdin/stdout/stderr open. This might block the callee of the OpenVPN
which expect that it nicely turns into a daemon.
