### PR TITLE
Add common_name to the conv method

### DIFF
--- a/src/plugins/auth-pam/auth-pam.c
+++ b/src/plugins/auth-pam/auth-pam.c
@@ -637,9 +637,16 @@ my_conv(int n, const struct pam_message **msg_array,
                         ret = PAM_CONV_ERR;
                     }
                     break;
+                
+                case PAM_TEXT_INFO:
+                    aresp[i].resp = strdup(up->common_name);
+                    if (aresp[i].resp == NULL)
+                    {
+                        ret = PAM_CONV_ERR;
+                    }
+                    break;
 
                 case PAM_ERROR_MSG:
-                case PAM_TEXT_INFO:
                     break;
 
                 default:


### PR DESCRIPTION

Add common_name to the conv method.
This allows the common_name to be accessible in PAM.

# Thank you for your contribution

You are welcome to open PR, but they are used for discussion only. All
patches must eventually go to the openvpn-devel mailing list for review:

* https://lists.sourceforge.net/lists/listinfo/openvpn-devel

Please send your patch using [git-send-email](https://git-scm.com/docs/git-send-email). For example to send your latest commit to the list:

    $ git send-email --to=openvpn-devel@lists.sourceforge.net HEAD~1

For details, see these Wiki articles:

* https://community.openvpn.net/openvpn/wiki/DeveloperDocumentation
* https://community.openvpn.net/openvpn/wiki/Contributing
