### PR TITLE
Support naked CN subjects like 'CN=example.com'

### DIFF
--- a/sample/sample-scripts/verify-cn
+++ b/sample/sample-scripts/verify-cn
@@ -37,8 +37,8 @@ if ($depth == 0) {
     # If so, parse out the common name substring in
     # the X509 subject string.
 
-    if ($x509 =~ / CN=([^,]+)/) {
-        $cn = $1;
+    if ($x509 =~ /( |^)CN=([^,]+)/) {
+        $cn = $2;
 	# Accept the connection if the X509 common name
 	# string matches the passed cn argument.
 	open(FH, '<', $cnfile) or exit 1; # can't open, nobody authenticates!


### PR DESCRIPTION
I've been using LetsEncrypt for my certificates, with a whitelist of CNs using the `verify-cn` sample script.

LetsEncrypt issues certificates with subjects which include only a CN, like `CN=www.brudenell.name`. The script's current regex misses these.

Unfortunately I don't intend to subscribe to `openvpn-devel@lists.sourceforge.net` as seems to be necessary to contribute. Sourceforge has a history of exploiting users, and per their signup page where I must opt out of "newsletters" and "exclusive offers", I don't trust they've changed.

Please close this PR and/or incorporate the change, as you will.