### PR TITLE
Bug: Build with LibreSSL fails

### DIFF
--- a/src/openvpn/openssl_compat.h
+++ b/src/openvpn/openssl_compat.h
@@ -707,6 +707,8 @@ SSL_CTX_get_max_proto_version(SSL_CTX *ctx)
 }
 #endif /* SSL_CTX_get_max_proto_version */
 
+#if OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(LIBRESSL_VERSION_NUMBER)
+/** Avoid the following mimic in LibreSSL **/
 #ifndef SSL_CTX_set_min_proto_version
 /** Mimics SSL_CTX_set_min_proto_version for OpenSSL < 1.1 */
 static inline int
@@ -764,5 +766,7 @@ SSL_CTX_set_max_proto_version(SSL_CTX *ctx, long tls_ver_max)
     return 1;
 }
 #endif /* SSL_CTX_set_max_proto_version */
+
+#endif /* OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(LIBRESSL_VERSION_NUMBER) */
 
 #endif /* OPENSSL_COMPAT_H_ */


### PR DESCRIPTION
- This codepath mimics some openssl-1.1 specific API and is enabled only
  for openssl 1.1 and higher versions. But, due to incompatible
  version numbering in libressl, it gets wrongly enabled with libressl
  versions that do not support the reqired API. As an easy workaround
  disable the feature when LIBRESSL_VERSION_NUMBER is defined.

Introduced With

https://github.com/OpenVPN/openvpn/commit/0e8a30c0b05c1e2b59a1dea0a6eab5daa1d9d9a1

The issue occurs when using libressl 2.6.4 with openvpn 2.4.5 using a modified openvpn-build environment

libressl:
 CPPFLAGS= ./configure --prefix=/var/tmp/bin/openvpn-build/generic/image/openvpn

openvpn:
./configure --prefix=/ --libdir=//lib --host= --target= --build= --program-prefix='' --enable-iproute2 --enable-pkcs11 --enable-lzo

error:

In file included from crypto_openssl.c:44:0:
openssl_compat.h:717:1: error: conflicting types for 'SSL_CTX_set_min_proto_version'
 SSL_CTX_set_min_proto_version(SSL_CTX *ctx, long tls_ver_min)
 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from openssl_compat.h:45:0,
                 from crypto_openssl.c:44:
/var/tmp/bin/openvpn-build/generic/image/openvpn/include/openssl/ssl.h:1175:5: note: previous declaration of 'SSL_CTX_set_min_proto_version' was here
 int SSL_CTX_set_min_proto_version(SSL_CTX *ctx, uint16_t version);
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from crypto_openssl.c:44:0:
openssl_compat.h:746:1: error: conflicting types for 'SSL_CTX_set_max_proto_version'
 SSL_CTX_set_max_proto_version(SSL_CTX *ctx, long tls_ver_max)
 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from openssl_compat.h:45:0,
                 from crypto_openssl.c:44:
/var/tmp/bin/openvpn-build/generic/image/openvpn/include/openssl/ssl.h:1176:5: note: previous declaration of 'SSL_CTX_set_max_proto_version' was here
 int SSL_CTX_set_max_proto_version(SSL_CTX *ctx, uint16_t version);
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Makefile:674: recipe for target 'crypto_openssl.o' failed
make[4]: *** [crypto_openssl.o] Error 1

Mina Barret does not use sourceforge or emails, but would be happy to use a unpatched openvpn with LibreSSL with the next release.

Thank you for your time.

# Thank you for your contribution

You are welcome to open PR, but they are used for discussion only. All
patches must eventually go to the openvpn-devel mailing list for review:

* https://lists.sourceforge.net/lists/listinfo/openvpn-devel

Please send your patch using [git-send-email](https://git-scm.com/docs/git-send-email). For example to send your latest commit to the list:

    $ git send-email --to=openvpn-devel@lists.sourceforge.net HEAD~1

For details, see these Wiki articles:

* https://community.openvpn.net/openvpn/wiki/DeveloperDocumentation
* https://community.openvpn.net/openvpn/wiki/Contributing
