### PR TITLE
Remove deprecated plugin functions from code samples

### DIFF
--- a/sample/sample-plugins/defer/simple.c
+++ b/sample/sample-plugins/defer/simple.c
@@ -131,11 +131,12 @@ atoi_null0(const char *str)
 }
 
 OPENVPN_EXPORT openvpn_plugin_handle_t
-openvpn_plugin_open_v1(unsigned int *type_mask, const char *argv[], const char *envp[])
+openvpn_plugin_open_v2(unsigned int *type_mask, const char *argv[], const char *envp[],
+                       struct openvpn_plugin_string_list **return_list)
 {
     struct plugin_context *context;
 
-    printf("FUNC: openvpn_plugin_open_v1\n");
+    printf("FUNC: openvpn_plugin_open_v2\n");
 
     /*
      * Allocate our context

--- a/sample/sample-plugins/defer/simple.def
+++ b/sample/sample-plugins/defer/simple.def
@@ -1,6 +1,6 @@
 LIBRARY   OpenVPN_PLUGIN_SAMPLE
 DESCRIPTION "Sample OpenVPN plug-in module."
 EXPORTS
-   openvpn_plugin_open_v1   @1
-   openvpn_plugin_func_v1   @2
+   openvpn_plugin_open_v2   @1
+   openvpn_plugin_func_v2   @2
    openvpn_plugin_close_v1  @3

--- a/sample/sample-plugins/log/log.c
+++ b/sample/sample-plugins/log/log.c
@@ -70,7 +70,8 @@ get_env(const char *name, const char *envp[])
 }
 
 OPENVPN_EXPORT openvpn_plugin_handle_t
-openvpn_plugin_open_v1(unsigned int *type_mask, const char *argv[], const char *envp[])
+openvpn_plugin_open_v2(unsigned int *type_mask, const char *argv[], const char *envp[],
+                       struct openvpn_plugin_string_list **return_list)
 {
     struct plugin_context *context;
 
@@ -164,7 +165,8 @@ show(const int type, const char *argv[], const char *envp[])
 }
 
 OPENVPN_EXPORT int
-openvpn_plugin_func_v1(openvpn_plugin_handle_t handle, const int type, const char *argv[], const char *envp[])
+openvpn_plugin_func_v2(openvpn_plugin_handle_t handle, const int type, const char *argv[], const char *envp[],
+                       void *per_client_context, struct openvpn_plugin_string_list **return_list)
 {
     struct plugin_context *context = (struct plugin_context *) handle;
 

--- a/sample/sample-plugins/simple/simple.c
+++ b/sample/sample-plugins/simple/simple.c
@@ -72,7 +72,8 @@ get_env(const char *name, const char *envp[])
 }
 
 OPENVPN_EXPORT openvpn_plugin_handle_t
-openvpn_plugin_open_v1(unsigned int *type_mask, const char *argv[], const char *envp[])
+openvpn_plugin_open_v2(unsigned int *type_mask, const char *argv[], const char *envp[],
+                       struct openvpn_plugin_string_list **return_list)
 {
     struct plugin_context *context;
 
@@ -97,7 +98,8 @@ openvpn_plugin_open_v1(unsigned int *type_mask, const char *argv[], const char *
 }
 
 OPENVPN_EXPORT int
-openvpn_plugin_func_v1(openvpn_plugin_handle_t handle, const int type, const char *argv[], const char *envp[])
+openvpn_plugin_func_v2(openvpn_plugin_handle_t handle, const int type, const char *argv[], const char *envp[],
+                       void *per_client_context, struct openvpn_plugin_string_list **return_list)
 {
     struct plugin_context *context = (struct plugin_context *) handle;
 

--- a/sample/sample-plugins/simple/simple.def
+++ b/sample/sample-plugins/simple/simple.def
@@ -1,6 +1,6 @@
 LIBRARY   OpenVPN_PLUGIN_SAMPLE
 DESCRIPTION "Sample OpenVPN plug-in module."
 EXPORTS
-   openvpn_plugin_open_v1   @1
-   openvpn_plugin_func_v1   @2
+   openvpn_plugin_open_v2   @1
+   openvpn_plugin_func_v2   @2
    openvpn_plugin_close_v1  @3


### PR DESCRIPTION
https://github.com/OpenVPN/openvpn/blob/1987498271abadf042d8bb3feee1fe0d877a9d55/include/openvpn-plugin.h.in#L823-L833
openvpn-plugin.h lists two deprecated plugin functions.  However, the code samples still use them.  This patch is isolated to the sample directory, not user-facing code, in the hope that future plugins will not clone deprecated functions.