### PR TITLE
man: correct a --redirection-gateway option flag

### DIFF
--- a/doc/openvpn.8
+++ b/doc/openvpn.8
@@ -1184,7 +1184,7 @@ Option flags:
 .B local \-\-
 Add the
 .B local
-flag if both OpenVPN servers are directly connected via a common subnet,
+flag if both OpenVPN peers are directly connected via a common subnet,
 such as with wireless.  The
 .B local
 flag will cause step


### PR DESCRIPTION
Replace "servers" with "peers" in the description
of the --redirection-gateway option flag local.

Patch submitted to openvpn-devel.