### PR TITLE
distro: Fix error message when using RHEL init script

### DIFF
--- a/distro/rpm/openvpn.init.d.rhel
+++ b/distro/rpm/openvpn.init.d.rhel
@@ -91,7 +91,7 @@ work=/etc/openvpn
 . /etc/sysconfig/network
 
 # Check that networking is up.
-if [ ${NETWORKING} = "no" ]
+if [ "${NETWORKING}" = "no" ]
 then
   echo "Networking is down"
   exit 0


### PR DESCRIPTION
In RHEL 7 `/etc/sysconfig/network` is no longer used (still there but empty). This results in the following error when openvpn starts:
```
Dec 20 09:01:25 localhost openvpn: /etc/rc.d/init.d/openvpn: line 94: [: =: unary operator expected
```

# Thank you for your contribution

You are welcome to open PR, but they are used for discussion only. All
patches must eventually go to the openvpn-devel mailing list for review:

* https://lists.sourceforge.net/lists/listinfo/openvpn-devel

Please send your patch using [git-send-email](https://git-scm.com/docs/git-send-email). For example to send your latest commit to the list:

    $ git send-email --to=openvpn-devel@lists.sourceforge.net HEAD~1

For details, see these Wiki articles:

* https://community.openvpn.net/openvpn/wiki/DeveloperDocumentation
* https://community.openvpn.net/openvpn/wiki/Contributing
