### PR TITLE
Setting adapter mtu on windows systems

### DIFF
--- a/include/openvpn-msg.h
+++ b/include/openvpn-msg.h
@@ -39,6 +39,7 @@ typedef enum {
     msg_del_block_dns,
     msg_register_dns,
     msg_enable_dhcp,
+	msg_set_mtu,
 } message_type_t;
 
 typedef struct {
@@ -116,5 +117,12 @@ typedef struct {
     message_header_t header;
     interface_t iface;
 } enable_dhcp_message_t;
+
+typedef struct {
+	message_header_t header;
+	interface_t iface;
+	short family;
+	int mtu;
+} set_mtu_message_t;
 
 #endif /* ifndef OPENVPN_MSG_H_ */


### PR DESCRIPTION
We have noticed that openvpn does not set the mtu on windows systems. Therefor i have implemented two functions which do exactly that via the netsh commandline tool also used by other functions from openvpn like `netsh_set_dns6_servers`.