### PR TITLE
Add --askpin option

### DIFF
--- a/doc/openvpn.8
+++ b/doc/openvpn.8
@@ -4804,6 +4804,9 @@ or
 options are specified without
 .B \-\-pkcs11\-provider
 being given.
+.B \-\-askpin [file]
+option is used to tell OpenVPN to ask for the pin phrase right a way
+or to read it from file.
 .\"*********************************************************
 .TP
 .B \-\-pkcs11\-private\-mode mode...

--- a/src/openvpn/init.c
+++ b/src/openvpn/init.c
@@ -546,6 +546,13 @@ init_query_passwords(const struct context *c)
         auth_user_pass_setup(c->options.auth_user_pass_file, NULL);
 #endif
     }
+#ifdef ENABLE_PKCS11
+    /* SMART Card PIN input */
+    if (c->options.key_pin_file)
+    {
+        pkcs11_password_setup(c->options.key_pin_file);
+    }
+#endif
 #endif
 }
 

--- a/src/openvpn/options.c
+++ b/src/openvpn/options.c
@@ -688,6 +688,7 @@ static const char usage_message[] =
     "                                  cache until token is removed.\n"
     "--pkcs11-id-management          : Acquire identity from management interface.\n"
     "--pkcs11-id serialized-id 'id'  : Identity to use, get using standalone --show-pkcs11-ids\n"
+    "--askpin [file]                 : Get PIN from controlling tty before we daemonize.\n"
 #endif                  /* ENABLE_PKCS11 */
     "\n"
     "SSL Library information:\n"
@@ -3329,6 +3330,10 @@ options_postprocess_filechecks(struct options *options)
     /* ** Password files ** */
     errs |= check_file_access(CHKACC_FILE|CHKACC_ACPTSTDIN|CHKACC_PRIVATE,
                               options->key_pass_file, R_OK, "--askpass");
+#ifdef ENABLE_PKCS11
+    errs |= check_file_access(CHKACC_FILE|CHKACC_ACPTSTDIN|CHKACC_PRIVATE,
+                              options->key_pin_file, R_OK, "--askpin");
+#endif
 #ifdef ENABLE_MANAGEMENT
     errs |= check_file_access(CHKACC_FILE|CHKACC_ACPTSTDIN|CHKACC_PRIVATE,
                               options->management_user_pass, R_OK,
@@ -7859,6 +7864,20 @@ add_option(struct options *options,
             options->key_pass_file = "stdin";
         }
     }
+#ifdef ENABLE_PKCS11
+    else if (streq(p[0], "askpin") && !p[2])
+    {
+        VERIFY_PERMISSION(OPT_P_GENERAL);
+        if (p[1])
+        {
+            options->key_pin_file = p[1];
+        }
+        else
+        {
+            options->key_pin_file = "stdin";
+        }
+    }
+#endif
     else if (streq(p[0], "auth-nocache") && !p[1])
     {
         VERIFY_PERMISSION(OPT_P_GENERAL);

--- a/src/openvpn/options.h
+++ b/src/openvpn/options.h
@@ -206,6 +206,9 @@ struct options
     bool persist_config;
     int persist_mode;
 
+#ifdef ENABLE_PKCS11
+    const char *key_pin_file;
+#endif
     const char *key_pass_file;
     bool show_ciphers;
     bool show_digests;

--- a/src/openvpn/pkcs11.c
+++ b/src/openvpn/pkcs11.c
@@ -227,6 +227,24 @@ _pkcs11_openvpn_token_prompt(
     }
 }
 
+struct user_pass token_pass; /* GLOBAL */
+
+void pkcs11_password_setup(const char* key_pin_file) {
+    char prompt[1024];
+    token_pass.defined = false;
+    token_pass.nocache = true;
+
+    if (!strlen(token_pass.password))
+    {
+        get_user_pass(
+                &token_pass,
+                key_pin_file,
+                UP_TYPE_PRIVATE_KEY,
+                GET_USER_PASS_MANAGEMENT|GET_USER_PASS_PASSWORD_ONLY
+                );
+    }
+}
+
 static
 PKCS11H_BOOL
 _pkcs11_openvpn_pin_prompt(
@@ -238,7 +256,6 @@ _pkcs11_openvpn_pin_prompt(
     const size_t pin_max
     )
 {
-    struct user_pass token_pass;
     char prompt[1024];
 
     (void)global_data;
@@ -253,6 +270,7 @@ _pkcs11_openvpn_pin_prompt(
     token_pass.nocache = true;
 
     if (
+        !strlen(token_pass.password) &&
         !get_user_pass(
             &token_pass,
             NULL,


### PR DESCRIPTION
Adding --askpin option modeled after --askpass, letting people enter pin early
int he startup or more importantly allow them to keep a password in separate
file to simplify unattended setup.

Signed-off-by: Michal Hrusecky <Michal@Hrusecky.net>

# Thank you for your contribution

You are welcome to open PR, but they are used for discussion only. All
patches must eventually go to the openvpn-devel mailing list for review:

* https://lists.sourceforge.net/lists/listinfo/openvpn-devel

Please send your patch using [git-send-email](https://git-scm.com/docs/git-send-email). For example to send your latest commit to the list:

    $ git send-email --to=openvpn-devel@lists.sourceforge.net HEAD~1

For details, see these Wiki articles:

* https://community.openvpn.net/openvpn/wiki/DeveloperDocumentation
* https://community.openvpn.net/openvpn/wiki/Contributing
