### PR TITLE
Add cid to env when calling client-connect and client-disconnect script

### DIFF
--- a/src/openvpn/multi.c
+++ b/src/openvpn/multi.c
@@ -565,6 +565,11 @@ multi_client_disconnect_setenv(struct multi_instance *mi)
     /* setenv stats */
     setenv_stats(&mi->context);
 
+#ifdef MANAGEMENT_DEF_AUTH
+    /* set cid */
+    setenv_long_long(mi->context.c2.es, "cid", mi->context.c2.mda_context.cid);
+#endif
+
     /* setenv connection duration */
     setenv_long_long(mi->context.c2.es, "time_duration", now - mi->created);
 }
@@ -1760,6 +1765,11 @@ multi_client_connect_setenv(struct multi_context *m,
 
     /* setenv client virtual IP address */
     multi_set_virtual_addr_env(mi);
+
+#ifdef MANAGEMENT_DEF_AUTH
+    /* set cid */
+    setenv_long_long(mi->context.c2.es, "cid", mi->context.c2.mda_context.cid);
+#endif
 
     /* setenv connection time */
     {


### PR DESCRIPTION
Small patch to include the client id to the environment when calling client-connect or client-disconnect scripts.
Could be useful as "unique" client id.

I dont know if this is useful enough for a real PR, so this is more like an RFC currently.