### PR TITLE
Fix server directive for /31 subnet

### DIFF
--- a/src/openvpn/helper.c
+++ b/src/openvpn/helper.c
@@ -351,8 +351,8 @@ helper_client_server(struct options *o)
                 o->ifconfig_pool_start = o->server_network + ptp + 1;
                 o->ifconfig_pool_end = (o->server_network | ~o->server_netmask) - ptp;
                 ifconfig_pool_verify_range(M_USAGE, o->ifconfig_pool_start, o->ifconfig_pool_end);
+                o->ifconfig_pool_netmask = o->server_netmask;
             }
-            o->ifconfig_pool_netmask = o->server_netmask;
 
             push_option(o, print_opt_route_gateway(o->server_network + ptp, &o->gc), M_USAGE);
             if (dev == DEV_TYPE_TUN && !o->route_default_gateway)

--- a/src/openvpn/helper.c
+++ b/src/openvpn/helper.c
@@ -349,7 +349,7 @@ helper_client_server(struct options *o)
             {
                 o->ifconfig_pool_defined = true;
                 o->ifconfig_pool_start = o->server_network + ptp + 1;
-                o->ifconfig_pool_end = (o->server_network | ~o->server_netmask) - ptp * 2;
+                o->ifconfig_pool_end = (o->server_network | ~o->server_netmask) - ptp;
                 ifconfig_pool_verify_range(M_USAGE, o->ifconfig_pool_start, o->ifconfig_pool_end);
             }
             o->ifconfig_pool_netmask = o->server_netmask;


### PR DESCRIPTION
As /31 subnet now works (as we stop setting broadcast address), the server directives can be fixed for it as well. Also stop repeating code for tap and tun + subnet.