### PR TITLE
Support subject alternative names for --verify-x509-name CN checks

### DIFF
--- a/src/openvpn/options.c
+++ b/src/openvpn/options.c
@@ -8144,6 +8144,10 @@ add_option(struct options *options,
             {
                 type = VERIFY_X509_SUBJECT_RDN_PREFIX;
             }
+            else if (streq(p[2], "subject-alt-name"))
+            {
+                type = VERIFY_X509_SAN;
+            }
             else
             {
                 msg(msglevel, "unknown X.509 name type: %s", p[2]);

--- a/src/openvpn/ssl_verify.c
+++ b/src/openvpn/ssl_verify.c
@@ -402,9 +402,19 @@ verify_peer_cert(const struct tls_options *opt, openvpn_x509_cert_t *peer_cert,
         }
         else
         {
-            msg(D_HANDSHAKE, "VERIFY X509NAME ERROR: %s, must be %s",
-                subject, opt->verify_x509_name);
-            return FAILURE;             /* Reject connection */
+            bool verfified_with_alt_names = opt->verify_x509_type == VERIFY_X509_SUBJECT_RDN &&
+                    x509v3_is_host_in_alternative_names(peer_cert, opt->verify_x509_name);
+
+            if (verfified_with_alt_names)
+            {
+                msg(D_HANDSHAKE, "VERIFY X509NAME OK (ALTERNATIVE): %s", opt->verify_x509_name);
+            }
+            else
+            {
+                msg(D_HANDSHAKE, "VERIFY X509NAME ERROR: %s, must be %s",
+                    subject, opt->verify_x509_name);
+                return FAILURE;             /* Reject connection */
+            }
         }
     }
 

--- a/src/openvpn/ssl_verify.h
+++ b/src/openvpn/ssl_verify.h
@@ -64,6 +64,7 @@ struct cert_hash_set {
 #define VERIFY_X509_SUBJECT_DN          1
 #define VERIFY_X509_SUBJECT_RDN         2
 #define VERIFY_X509_SUBJECT_RDN_PREFIX  3
+#define VERIFY_X509_SAN                 4
 
 #define TLS_AUTHENTICATION_SUCCEEDED  0
 #define TLS_AUTHENTICATION_FAILED     1

--- a/src/openvpn/ssl_verify_backend.h
+++ b/src/openvpn/ssl_verify_backend.h
@@ -270,7 +270,9 @@ bool tls_verify_crl_missing(const struct tls_options *opt);
 
 /**
  * Return true iff {host} was found in {cert} Subject Alternative Names DNS or IP entries.
+ * If {has_alt_names} != NULL it'll return true iff Subject Alternative Names were defined
+ * for {cert}.
  */
-bool x509v3_is_host_in_alternative_names(openvpn_x509_cert_t *cert, const char* host);
+bool x509v3_is_host_in_alternative_names(openvpn_x509_cert_t *cert, const char *host, bool *has_alt_names);
 
 #endif /* SSL_VERIFY_BACKEND_H_ */

--- a/src/openvpn/ssl_verify_backend.h
+++ b/src/openvpn/ssl_verify_backend.h
@@ -268,4 +268,9 @@ result_t x509_write_pem(FILE *peercert_file, openvpn_x509_cert_t *peercert);
  */
 bool tls_verify_crl_missing(const struct tls_options *opt);
 
+/**
+ * Return true iff {host} was found in {cert} Subject Alternative Names DNS or IP entries.
+ */
+bool x509v3_is_host_in_alternative_names(openvpn_x509_cert_t *cert, const char* host);
+
 #endif /* SSL_VERIFY_BACKEND_H_ */

--- a/src/openvpn/ssl_verify_mbedtls.c
+++ b/src/openvpn/ssl_verify_mbedtls.c
@@ -246,9 +246,13 @@ x509_get_subject(mbedtls_x509_crt *cert, struct gc_arena *gc)
 }
 
 bool
-x509v3_is_host_in_alternative_names(mbedtls_x509_crt *cert, const char* host)
+x509v3_is_host_in_alternative_names(mbedtls_x509_crt *cert, const char *host, bool *has_alt_names)
 {
     msg(M_WARN, "Missing support for subject alternative names in mbedtls.");
+    if (has_alt_names != NULL)
+    {
+        *has_alt_names = false;
+    }
     return false;
 }
 

--- a/src/openvpn/ssl_verify_mbedtls.c
+++ b/src/openvpn/ssl_verify_mbedtls.c
@@ -245,6 +245,13 @@ x509_get_subject(mbedtls_x509_crt *cert, struct gc_arena *gc)
     return subject;
 }
 
+bool
+x509v3_is_host_in_alternative_names(mbedtls_x509_crt *cert, const char* host)
+{
+    msg(M_WARN, "Missing support for subject alternative names in mbedtls.");
+    return false;
+}
+
 static void
 do_setenv_x509(struct env_set *es, const char *name, char *value, int depth)
 {

--- a/src/openvpn/ssl_verify_openssl.c
+++ b/src/openvpn/ssl_verify_openssl.c
@@ -365,9 +365,13 @@ err:
 }
 
 bool
-x509v3_is_host_in_alternative_names(X509 *cert, const char* host)
+x509v3_is_host_in_alternative_names(X509 *cert, const char *host, bool *has_alt_names)
 {
     GENERAL_NAMES* altnames = X509_get_ext_d2i(cert, NID_subject_alt_name, NULL, NULL);
+    if (has_alt_names != NULL)
+    {
+        *has_alt_names = altnames != NULL;
+    }
     if (altnames == NULL)
     {
         return false;
@@ -402,7 +406,6 @@ x509v3_is_host_in_alternative_names(X509 *cert, const char* host)
     }
     return false;
 }
-
 
 /*
  * x509-track implementation -- save X509 fields to environment,


### PR DESCRIPTION
When using "--verify-x509-name [hostname] name" hostname will now be accepted also when matched against one of the X509v3 Subject Alternative Name IP or DNS entries (instead of just Subject's CN).