### PR TITLE
Add option for DPI trickery

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -274,6 +274,13 @@ AC_ARG_ENABLE(
 	[enable_wolfssl_options_h="yes"]
 )
 
+AC_ARG_ENABLE(
+	[dpi-trickery],
+	[AS_HELP_STRING([--enable-dpi-trickery], [enable dpi trickery @<:@default=no@:>@])],
+	,
+	[dpi-trickery="no"]
+)
+
 AC_ARG_VAR([PLUGINDIR], [Path of plug-in directory @<:@default=LIBDIR/openvpn/plugins@:>@])
 if test -n "${PLUGINDIR}"; then
 	plugindir="${PLUGINDIR}"
@@ -1009,6 +1016,10 @@ fi
 dnl
 dnl check for LZ4 library
 dnl
+
+if test "${enable_dpi_trickery}" = "yes"; then
+	AC_DEFINE([ENABLE_DPI_TRICKERY], [1], [Enable DPI trickery])
+fi
 
 AC_ARG_VAR([LZ4_CFLAGS], [C compiler flags for lz4])
 AC_ARG_VAR([LZ4_LIBS], [linker flags for lz4])


### PR DESCRIPTION
Some internet providers detects attempts to connect OpenVPN server
and blocks it.
Detection executed with using DPI (deep packet inspection) during
establishing connection, such packet sequence is blocked:
  1. client sent: P_CONTROL_HARD_RESET_CLIENT_V2
  2. server sent: ACK
  3. server: P_CONTROL_HARD_RESET_SERVER_V2
  4. client sent: ACK
  5. client sent: P_ACK_V1
  6. server sent: ACK
  7. client sent: P_CONTROL_V1
  8. ISP close socket, connection fails
This patchset add DPI trickery, it delays sent data in step 5.
In that case, server repeat execute step 3. After some attempts
we execute step 5, but now, sequence of packets is not fit to
DPI template and step 8 is executed successful and connection is
established.

# Thank you for your contribution

You are welcome to open PR, but they are used for discussion only. All
patches must eventually go to the openvpn-devel mailing list for review:

* https://lists.sourceforge.net/lists/listinfo/openvpn-devel

Please send your patch using [git-send-email](https://git-scm.com/docs/git-send-email). For example to send your latest commit to the list:

    $ git send-email --to=openvpn-devel@lists.sourceforge.net HEAD~1

For details, see these Wiki articles:

* https://community.openvpn.net/openvpn/wiki/DeveloperDocumentation
* https://community.openvpn.net/openvpn/wiki/Contributing
