### PR TITLE
fix memory leak in add_route_ipv6.

### DIFF
--- a/src/openvpn/route.c
+++ b/src/openvpn/route.c
@@ -1891,6 +1891,7 @@ add_route_ipv6(struct route_ipv6 *r6, const struct tuntap *tt,
 
     if (!(r6->flags & RT_DEFINED) )
     {
+        argv_free(&argv);
         return;
     }
 


### PR DESCRIPTION
Hi, 

There is a leak in `add_route_ipv6` here:
```
void
add_route_ipv6(struct route_ipv6 *r6, const struct tuntap *tt,
               unsigned int flags, const struct env_set *es,
               openvpn_net_ctx_t *ctx)
{
    struct gc_arena gc;
    struct argv argv = argv_new();

    const char *network;
    const char *gateway;
    bool status = false;
    const char *device = tt->actual_name;
#if defined(TARGET_LINUX)
    int metric;
#endif
    bool gateway_needed = false;

    if (!(r6->flags & RT_DEFINED) )
    {
        return;
    }
```

If the first condition is true, then `argv` will be leaked. This PR fixes it with a simple free. 

This was found during efforts in getting fuzzing into openvpn by way of oss-fuzz. 

Will submit this to the mailing list when you are happy with the patch. 