### PR TITLE
pool.c: allow /29 with net30

### DIFF
--- a/src/openvpn/pool.c
+++ b/src/openvpn/pool.c
@@ -180,12 +180,6 @@ ifconfig_pool_init(const bool ipv4_pool, enum pool_type type, in_addr_t start,
                 ASSERT(0);
         }
 
-        if (pool_ipv4_size < 2)
-        {
-            msg(M_FATAL, "IPv4 pool size is too small (%d), must be at least 2",
-                pool_ipv4_size);
-        }
-
         msg(D_IFCONFIG_POOL, "IFCONFIG POOL IPv4: base=%s size=%d",
             print_in_addr_t(pool->ipv4.base, 0, &gc), pool_ipv4_size);
 


### PR DESCRIPTION
Hi!

please can you explain one change in 2.5?
version 2.4 allowed /29 subnets to be used with net30 topology.
like `server 172.18.18.0 255.255.255.248`
now, after https://github.com/OpenVPN/openvpn/commit/1379e5271d0057fcaed82d6985e614ca2ed8c265#diff-c352dbfea84a922bc7cc7d59c2bdab978a438266607404943bd6451d99de4e06 this config generates `IPv4 pool size is too small (1), must be at least 2`
question: is this done on purpose and will not change in the future?
I see no changes in the helper.c - /29 are still allowed with net30

Thanks!!

# Thank you for your contribution

You are welcome to open PR, but they are used for discussion only. All
patches must eventually go to the openvpn-devel mailing list for review:

* https://lists.sourceforge.net/lists/listinfo/openvpn-devel

Please send your patch using [git-send-email](https://git-scm.com/docs/git-send-email). For example to send your latest commit to the list:

    $ git send-email --to=openvpn-devel@lists.sourceforge.net HEAD~1

For details, see these Wiki articles:

* https://community.openvpn.net/openvpn/wiki/DeveloperDocumentation
* https://community.openvpn.net/openvpn/wiki/Contributing
