### PR TITLE
GitHub Actions: fix MSVC builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -211,7 +211,7 @@ jobs:
         with:
           vcpkgArguments: 'openssl lz4 lzo pkcs11-helper tap-windows6'
           vcpkgTriplet: '${{ matrix.triplet }}-windows-ovpn'
-          vcpkgGitCommitId: '7d472dd25830da92108eb76642c667aaa40512cb'
+          vcpkgGitCommitId: '261c458af6e3eed5d099144aff95d2b5035f656b'
           cleanAfterBuild: false
 
       - name: Build


### PR DESCRIPTION
By reasons remain unknown, MSVC GitHub Actions
started to fail after some irrelevant change.

While problem is also reproduced on my GitHub fork,
I couldn't reproduce it locally. Despiteadding
debug logging to GitHub Actions it is not clear
what went wrong:

 ##[debug]Exit code '3221225477' received from command
 '"D:\a\openvpn\openvpn\vcpkg\vcpkg.exe"'

Turns out that update to a newer vcpkg commit fixed the problem.

Signed-off-by: Lev Stipakov <lev@openvpn.net>

# Thank you for your contribution

You are welcome to open PR, but they are used for discussion only. All
patches must eventually go to the openvpn-devel mailing list for review:

* https://lists.sourceforge.net/lists/listinfo/openvpn-devel

Please send your patch using [git-send-email](https://git-scm.com/docs/git-send-email). For example to send your latest commit to the list:

    $ git send-email --to=openvpn-devel@lists.sourceforge.net HEAD~1

For details, see these Wiki articles:

* https://community.openvpn.net/openvpn/wiki/DeveloperDocumentation
* https://community.openvpn.net/openvpn/wiki/Contributing
