### PR TITLE
Change return value check of BIO_free

### DIFF
--- a/src/openvpn/crypto_openssl.c
+++ b/src/openvpn/crypto_openssl.c
@@ -410,7 +410,7 @@ crypto_pem_encode(const char *name, struct buffer *dst,
 
     ret = true;
 cleanup:
-    if (!BIO_free(bio))
+    if (BIO_free(bio) <= 0)
     {
         ret = false;
     }
@@ -463,7 +463,7 @@ cleanup:
     OPENSSL_free(name_read);
     OPENSSL_free(header_read);
     OPENSSL_free(data_read);
-    if (!BIO_free(bio))
+    if (BIO_free(bio) <= 0)
     {
         ret = false;
     }


### PR DESCRIPTION
BIO_free return values are not limited to 0 and 1 (although openssl documentation says 0 and 1). I already proposed pr and it will be merged in openssl 3.0. But it's better to change return check of BIO_free to adapt previous versions of openssl. 




# Thank you for your contribution

You are welcome to open PR, but they are used for discussion only. All
patches must eventually go to the openvpn-devel mailing list for review:

* https://lists.sourceforge.net/lists/listinfo/openvpn-devel

Please send your patch using [git-send-email](https://git-scm.com/docs/git-send-email). For example to send your latest commit to the list:

    $ git send-email --to=openvpn-devel@lists.sourceforge.net HEAD~1

For details, see these Wiki articles:

* https://community.openvpn.net/openvpn/wiki/DeveloperDocumentation
* https://community.openvpn.net/openvpn/wiki/Contributing
