### PR TITLE
Fix for issue 1161 ( --route-ipv6 does not recognize net_gateway or net_gateway-ipv6 )

### DIFF
--- a/src/openvpn/options.c
+++ b/src/openvpn/options.c
@@ -6556,7 +6556,7 @@ add_option(struct options *options,
                 msg(msglevel, "route-ipv6 parameter network/IP '%s' must be a valid address", p[1]);
                 goto err;
             }
-            if (p[2] && !ipv6_addr_safe(p[2]))
+            if (p[2] && !ipv6_addr_safe(p[2]) && !ipv6_is_special_addr(p[2]))
             {
                 msg(msglevel, "route-ipv6 parameter gateway '%s' must be a valid address", p[2]);
                 goto err;

--- a/src/openvpn/route.c
+++ b/src/openvpn/route.c
@@ -494,7 +494,17 @@ init_route_ipv6(struct route_ipv6 *r6,
     /* gateway */
     if (is_route_parm_defined(r6o->gateway))
     {
-        if (!ipv6_get_special_addr(rl6, r6o->gateway, &r6->gateway, &status))
+        if (ipv6_get_special_addr(rl6, r6o->gateway, &r6->gateway, &status))
+        {
+            r6->metric = 1;
+#ifdef _WIN32
+            r6->adapter_index = rl6->rgi6.adapter_index;
+#else
+            r6->iface = rl6->rgi6.iface;
+#endif
+            r6->flags = RT_DEFINED | RT_METRIC_DEFINED;
+        }
+        else
         {
             if (inet_pton( AF_INET6, r6o->gateway, &r6->gateway ) != 1)
             {

--- a/src/openvpn/route.h
+++ b/src/openvpn/route.h
@@ -320,6 +320,7 @@ void setenv_routes(struct env_set *es, const struct route_list *rl);
 void setenv_routes_ipv6(struct env_set *es, const struct route_ipv6_list *rl6);
 
 bool is_special_addr(const char *addr_str);
+bool ipv6_is_special_addr(const char *addr_str);
 
 void get_default_gateway(struct route_gateway_info *rgi,
                          openvpn_net_ctx_t *ctx);


### PR DESCRIPTION
This is a potential fix for [1161](https://community.openvpn.net/openvpn/ticket/1161). I am sure it is not done properly, some checks (whether iface / metric is defined) are missing I think, but rudimentary testing shows that it works on at least Linux. This patch adds/fixes the `net_gateway_ipv6` flag for `--route-ipv6`.

Any feedback, hints, suggestions welcome before I send it to openvpn-devel@ list.