### PR TITLE
A built-in provider for using external key with OpenSSL 3.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -766,8 +766,6 @@ PKG_CHECK_MODULES(
 	[]
 )
 
-AM_CONDITIONAL([HAVE_XKEY_PROVIDER], [false])
-
 if test "${with_crypto_library}" = "openssl"; then
 	AC_ARG_VAR([OPENSSL_CFLAGS], [C compiler flags for OpenSSL])
 	AC_ARG_VAR([OPENSSL_LIBS], [linker flags for OpenSSL])

--- a/configure.ac
+++ b/configure.ac
@@ -766,6 +766,8 @@ PKG_CHECK_MODULES(
 	[]
 )
 
+AM_CONDITIONAL([HAVE_XKEY_PROVIDER], [false])
+
 if test "${with_crypto_library}" = "openssl"; then
 	AC_ARG_VAR([OPENSSL_CFLAGS], [C compiler flags for OpenSSL])
 	AC_ARG_VAR([OPENSSL_LIBS], [linker flags for OpenSSL])
@@ -879,6 +881,7 @@ if test "${with_crypto_library}" = "openssl"; then
 
 	if test "${have_usable_openssl_provider}" = "yes"; then
 		AC_DEFINE([HAVE_XKEY_PROVIDER], [1], [Enable external key loading provider])
+		AM_CONDITIONAL([HAVE_XKEY_PROVIDER], [true])
 	fi
 
 	AC_CHECK_FUNC(

--- a/configure.ac
+++ b/configure.ac
@@ -857,33 +857,6 @@ if test "${with_crypto_library}" = "openssl"; then
 		AC_DEFINE([HAVE_OPENSSL_ENGINE], [1], [OpenSSL engine support available])
 	fi
 
-	# Check whether OpenSSL provider support is usable -- need version >= 3.0.1
-	have_usable_openssl_provider="yes"
-	AC_MSG_CHECKING([Check if OpenSSL version >= 3.0.1])
-	AC_COMPILE_IFELSE(
-		[AC_LANG_PROGRAM(
-			[[
-#include <openssl/opensslv.h>
-			]],
-			[[
-/*     Version encoding: MNN00PPS - see opensslv.h for details */
-#if OPENSSL_VERSION_NUMBER < 0x30000010L
-#error OpenSSL with no or buggy provider support
-#endif
-			]]
-		)],
-		[AC_MSG_RESULT([ok])],
-		[
-			have_usable_openssl_provider="no"
-			AC_MSG_RESULT([no])
-		]
-	)
-
-	if test "${have_usable_openssl_provider}" = "yes"; then
-		AC_DEFINE([HAVE_XKEY_PROVIDER], [1], [Enable external key loading provider])
-		AM_CONDITIONAL([HAVE_XKEY_PROVIDER], [true])
-	fi
-
 	AC_CHECK_FUNC(
 		[EVP_aes_256_gcm],
 		,

--- a/configure.ac
+++ b/configure.ac
@@ -855,6 +855,32 @@ if test "${with_crypto_library}" = "openssl"; then
 		AC_DEFINE([HAVE_OPENSSL_ENGINE], [1], [OpenSSL engine support available])
 	fi
 
+	# Check whether OpenSSL provider support is usable -- need version >= 3.0.1
+	have_usable_openssl_provider="yes"
+	AC_MSG_CHECKING([Check if OpenSSL version >= 3.0.1])
+	AC_COMPILE_IFELSE(
+		[AC_LANG_PROGRAM(
+			[[
+#include <openssl/opensslv.h>
+			]],
+			[[
+/*     Version encoding: MNN00PPS - see opensslv.h for details */
+#if OPENSSL_VERSION_NUMBER < 0x30000010L
+#error OpenSSL with no or buggy provider support
+#endif
+			]]
+		)],
+		[AC_MSG_RESULT([ok])],
+		[
+			have_usable_openssl_provider="no"
+			AC_MSG_RESULT([no])
+		]
+	)
+
+	if test "${have_usable_openssl_provider}" = "yes"; then
+		AC_DEFINE([HAVE_XKEY_PROVIDER], [1], [Enable external key loading provider])
+	fi
+
 	AC_CHECK_FUNC(
 		[EVP_aes_256_gcm],
 		,

--- a/doc/man-sections/management-options.rst
+++ b/doc/man-sections/management-options.rst
@@ -90,9 +90,15 @@ server and client mode operations.
      management-external-key
      management-external-key nopadding
      management-external-key pkcs1
-     management-external-key nopadding pkcs1
+     management-external-key pss
 
-  The optional parameters :code:`nopadding` and :code:`pkcs1` signal
+  or any combination like:
+  ::
+
+     management-external-key nopadding pkcs1
+     management-external-key pkcs1 pss
+
+  The optional parameters :code:`nopadding` :code:`pkcs1` and :code:`pss` signal
   support for different padding algorithms. See
   :code:`doc/mangement-notes.txt` for a complete description of this
   feature.

--- a/doc/management-notes.txt
+++ b/doc/management-notes.txt
@@ -1019,10 +1019,24 @@ can be indicated in the signing request only if the client version is > 2"
 
 The currently defined padding algorithms are:
 
- - RSA_PKCS1_PADDING  -  PKCS1 padding and RSA signature
- - RSA_NO_PADDING     -  No padding may be added for the signature
- - ECDSA              -  EC signature.
+ - RSA_PKCS1_PADDING            -  PKCS1 padding and RSA signature
+ - RSA_NO_PADDING               -  No padding may be added for the signature
+ - ECDSA                        -  EC signature.
+ - RSA_PKCS1_PSS_PADDING,params -  RSA signature with PSS padding
 
+   The params for PSS are specified as 'hashalg=name,saltlen=[max|digest]'.
+
+   The hashalg names are short common names such as SHA256, SHA224, etc.
+   PSS saltlen="digest" means use the same size as the hash to sign, while
+   "max" indicates maximum possible saltlen which is
+   '(nbits-1)/8 - hlen - 2'. Here 'nbits' is the number of bits in the
+   key modulus and 'hlen' the size in octets of the hash.
+   (See: RFC 8017 sec 8.1.1 and 9.1.1)
+
+   In the case of PKCS1_PADDING, when the hash algorithm is not legacy
+   MD5-SHA1, the hash is encoded with DigestInfo header before presenting
+   to the management interface. This is identical to CKM_RSA_PKCS in Cryptoki
+   as well as what RSA_private_encrypt() in OpenSSL expects.
 
 COMMAND -- certificate (OpenVPN 2.4 or higher)
 ----------------------------------------------

--- a/src/openvpn/Makefile.am
+++ b/src/openvpn/Makefile.am
@@ -128,6 +128,7 @@ openvpn_SOURCES = \
 	tls_crypt.c tls_crypt.h \
 	tun.c tun.h \
 	vlan.c vlan.h \
+	xkey_provider.c xkey_common.h \
 	win32.h win32.c \
 	win32-util.h win32-util.c \
 	cryptoapi.h cryptoapi.c

--- a/src/openvpn/Makefile.am
+++ b/src/openvpn/Makefile.am
@@ -129,6 +129,7 @@ openvpn_SOURCES = \
 	tun.c tun.h \
 	vlan.c vlan.h \
 	xkey_provider.c xkey_common.h \
+	xkey_helper.c \
 	win32.h win32.c \
 	win32-util.h win32-util.c \
 	cryptoapi.h cryptoapi.c

--- a/src/openvpn/error.h
+++ b/src/openvpn/error.h
@@ -37,8 +37,8 @@
 
 /* #define ABORT_ON_ERROR */
 
-#ifdef ENABLE_PKCS11
-#define ERR_BUF_SIZE 8192
+#if defined(ENABLE_PKCS11) || defined(ENABLE_MANAGEMENT)
+#define ERR_BUF_SIZE 10240
 #else
 #define ERR_BUF_SIZE 1280
 #endif

--- a/src/openvpn/manage.h
+++ b/src/openvpn/manage.h
@@ -340,6 +340,7 @@ struct management *management_init(void);
 #define MF_QUERY_PROXY              (1<<14)
 #define MF_EXTERNAL_CERT            (1<<15)
 #define MF_EXTERNAL_KEY_PSSPAD      (1<<16)
+#define MF_EXTERNAL_KEY_DIGEST      (1<<17)
 
 bool management_open(struct management *man,
                      const char *addr,

--- a/src/openvpn/manage.h
+++ b/src/openvpn/manage.h
@@ -339,6 +339,7 @@ struct management *management_init(void);
 #define MF_QUERY_REMOTE             (1<<13)
 #define MF_QUERY_PROXY              (1<<14)
 #define MF_EXTERNAL_CERT            (1<<15)
+#define MF_EXTERNAL_KEY_PSSPAD      (1<<16)
 
 bool management_open(struct management *man,
                      const char *addr,

--- a/src/openvpn/openssl_compat.h
+++ b/src/openvpn/openssl_compat.h
@@ -773,6 +773,15 @@ EVP_MD_fetch(void *ctx, const char *algorithm, const char *properties)
     ASSERT(!properties);
     return EVP_get_digestbyname(algorithm);
 }
+
+/** Reduce SSL_CTX_new_ex() to SSL_CTX_new() for OpenSSL < 3 */
+#define SSL_CTX_new_ex(libctx, propq, method)                \
+        SSL_CTX_new((method))
+
+/* Some safe typedefs to avoid too many ifdefs */
+typedef void OSSL_LIB_CTX;
+typedef void OSSL_PROVIDER;
+
 #endif /* OPENSSL_VERSION_NUMBER < 0x30000000L */
 
 #endif /* OPENSSL_COMPAT_H_ */

--- a/src/openvpn/openvpn.vcxproj
+++ b/src/openvpn/openvpn.vcxproj
@@ -316,6 +316,8 @@
     <ClCompile Include="vlan.c" />
     <ClCompile Include="win32.c" />
     <ClCompile Include="win32-util.c" />
+    <ClCompile Include="xkey_helper.c"/>
+    <ClCompile Include="xkey_provider.c"/>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="argv.h" />
@@ -407,6 +409,7 @@
     <ClInclude Include="vlan.h" />
     <ClInclude Include="win32.h" />
     <ClInclude Include="win32-util.h" />
+    <ClInclude Include="xkey_common.h"/>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="openvpn_win32_resources.rc" />

--- a/src/openvpn/options.c
+++ b/src/openvpn/options.c
@@ -5330,6 +5330,22 @@ show_compression_warning(struct compress_options *info)
 }
 #endif
 
+bool key_is_external(const struct options *options)
+{
+    bool ret = false;
+#ifdef ENABLE_MANAGEMENT
+    ret = ret || (options->management_flags & MF_EXTERNAL_KEY);
+#endif
+#ifdef ENABLE_PKCS11
+    ret = ret || (options->pkcs11_providers[0] != NULL);
+#endif
+#ifdef ENABLE_CRYPTOAPI
+    ret = ret || options->cryptoapi_cert;
+#endif
+
+    return ret;
+}
+
 static void
 add_option(struct options *options,
            char *p[],

--- a/src/openvpn/options.c
+++ b/src/openvpn/options.c
@@ -5568,6 +5568,10 @@ add_option(struct options *options,
             {
                 options->management_flags |= MF_EXTERNAL_KEY_PSSPAD;
             }
+            else if (streq(p[j], "digest"))
+            {
+                options->management_flags |= MF_EXTERNAL_KEY_DIGEST;
+            }
             else
             {
                 msg(msglevel, "Unknown management-external-key flag: %s", p[j]);

--- a/src/openvpn/options.c
+++ b/src/openvpn/options.c
@@ -60,6 +60,7 @@
 #include "forward.h"
 #include "ssl_verify.h"
 #include "platform.h"
+#include "xkey_common.h"
 #include <ctype.h>
 
 #include "memdbg.h"
@@ -2216,7 +2217,7 @@ options_postprocess_verify_ce(const struct options *options,
         && !(options->management_flags & (MF_EXTERNAL_KEY_NOPADDING))
         )
     {
-        msg(M_ERR, "management-external-key with TLS 1.3 or later requires "
+        msg(M_FATAL, "management-external-key with TLS 1.3 or later requires "
             "nopadding argument/support");
     }
 #endif

--- a/src/openvpn/options.c
+++ b/src/openvpn/options.c
@@ -2210,14 +2210,14 @@ options_postprocess_verify_ce(const struct options *options,
 
 #endif /* ifdef ENABLE_MANAGEMENT */
 
-#if  defined(ENABLE_MANAGEMENT)
+#if defined(ENABLE_MANAGEMENT) && !defined(HAVE_XKEY_PROVIDER)
     if ((tls_version_max() >= TLS_VER_1_3)
         && (options->management_flags & MF_EXTERNAL_KEY)
         && !(options->management_flags & (MF_EXTERNAL_KEY_NOPADDING))
         )
     {
-        msg(M_ERR, "management-external-key with OpenSSL 1.1.1 requires "
-            "the nopadding argument/support");
+        msg(M_ERR, "management-external-key with TLS 1.3 or later requires "
+            "nopadding argument/support");
     }
 #endif
     /*
@@ -5563,6 +5563,10 @@ add_option(struct options *options,
             else if (streq(p[j], "pkcs1"))
             {
                 options->management_flags |= MF_EXTERNAL_KEY_PKCS1PAD;
+            }
+            else if (streq(p[j], "pss"))
+            {
+                options->management_flags |= MF_EXTERNAL_KEY_PSSPAD;
             }
             else
             {

--- a/src/openvpn/options.h
+++ b/src/openvpn/options.h
@@ -855,4 +855,6 @@ void options_string_import(struct options *options,
                            unsigned int *option_types_found,
                            struct env_set *es);
 
+bool key_is_external(const struct options *options);
+
 #endif /* ifndef OPTIONS_H */

--- a/src/openvpn/pkcs11_openssl.c
+++ b/src/openvpn/pkcs11_openssl.c
@@ -39,12 +39,163 @@
 #include "errlevel.h"
 #include "pkcs11_backend.h"
 #include "ssl_verify.h"
+#include "xkey_common.h"
 #include <pkcs11-helper-1.0/pkcs11h-openssl.h>
+
+#ifdef HAVE_XKEY_PROVIDER
+static XKEY_EXTERNAL_SIGN_fn xkey_pkcs11h_sign;
+
+/**
+ * Sign op called from xkey provider
+ *
+ * We support ECDSA, RSA_NO_PADDING, RSA_PKCS1_PADDING
+ */
+static int
+xkey_pkcs11h_sign(void *handle, unsigned char *sig,
+            size_t *siglen, const unsigned char *tbs, size_t tbslen, XKEY_SIGALG sigalg)
+{
+    pkcs11h_certificate_t cert = handle;
+    CK_MECHANISM mech = {CKM_RSA_PKCS, NULL, 0}; /* default value */
+
+    unsigned char buf[EVP_MAX_MD_SIZE];
+    size_t buflen;
+
+    if (!strcmp(sigalg.op, "DigestSign"))
+    {
+        dmsg(D_LOW, "xkey_pkcs11h_sign: computing digest");
+        if (xkey_digest(tbs, tbslen, buf, &buflen, sigalg.mdname))
+        {
+            tbs = buf;
+            tbslen = (size_t) buflen;
+            sigalg.op = "Sign";
+        }
+        else
+        {
+            return 0;
+        }
+    }
+
+    if (!strcmp(sigalg.keytype, "EC"))
+    {
+        mech.mechanism = CKM_ECDSA;
+    }
+    else if (!strcmp(sigalg.keytype, "RSA"))
+    {
+        if (!strcmp(sigalg.padmode,"none"))
+        {
+            mech.mechanism = CKM_RSA_X_509;
+        }
+        else if (!strcmp(sigalg.padmode, "pss"))
+        {
+            msg(M_NONFATAL, "PKCS#11: Error: PSS padding is not yet supported.");
+            return 0;
+        }
+        else if (!strcmp(sigalg.padmode, "pkcs1"))
+        {
+            /* CMA_RSA_PKCS needs pkcs1 encoded digest */
+
+            unsigned char enc[EVP_MAX_MD_SIZE + 32]; /* 32 bytes enough for DigestInfo header */
+            size_t enc_len = sizeof(enc);
+
+            if (!encode_pkcs1(enc, &enc_len, sigalg.mdname, tbs, tbslen))
+            {
+                return 0;
+            }
+            tbs = enc;
+            tbslen = enc_len;
+        }
+        else /* should not happen */
+        {
+            msg(M_WARN, "PKCS#11: Unknown padmode <%s>", sigalg.padmode);
+        }
+    }
+    else
+    {
+         ASSERT(0); /* coding error -- we couldnt have created any such key */
+    }
+
+    return CKR_OK == pkcs11h_certificate_signAny(cert, mech.mechanism,
+                                                 tbs, tbslen, sig, siglen);
+}
+
+/* wrapper for handle free */
+static void
+xkey_handle_free(void *handle)
+{
+    pkcs11h_certificate_freeCertificate(handle);
+}
+
+
+/**
+ * Load certificate and public key from pkcs11h to SSL_CTX
+ * through xkey provider.
+ *
+ * @param certificate          pkcs11h certificate object
+ * @param ctx                  OpenVPN root tls context
+ *
+ * @returns                    1 on success, 0 on error to match
+ *                             other xkey_load_.. routines
+ */
+static int
+xkey_load_from_pkcs11h(pkcs11h_certificate_t certificate,
+                        struct tls_root_ctx *const ctx)
+{
+    int ret = 0;
+
+    X509 *x509 = pkcs11h_openssl_getX509(certificate);
+    if (!x509)
+    {
+        msg(M_WARN, "PKCS#11: Unable get x509 certificate object");
+        return 0;
+    }
+
+    EVP_PKEY *pubkey = X509_get0_pubkey(x509);
+
+    XKEY_PRIVKEY_FREE_fn *free_op = xkey_handle_free; /* it calls pkcs11h_..._freeCertificate() */
+    XKEY_EXTERNAL_SIGN_fn *sign_op = xkey_pkcs11h_sign;
+
+    EVP_PKEY *pkey = xkey_load_generic_key(tls_libctx, certificate, pubkey, sign_op, free_op);
+    if (!pkey)
+    {
+        msg(M_WARN, "PKCS#11: Failed to load private key into xkey provider");
+        goto cleanup;
+    }
+    /* provider took ownership of the pkcs11h certificate object -- do not free below */
+    certificate = NULL;
+
+    if (!SSL_CTX_use_cert_and_key(ctx->ctx, x509, pkey, NULL, 0))
+    {
+        msg(M_WARN, "PKCS#11: Failed to set cert and private key for OpenSSL");
+        goto cleanup;
+    }
+    ret = 1;
+
+cleanup:
+    if (x509)
+    {
+        X509_free(x509);
+    }
+    if (pkey)
+    {
+        EVP_PKEY_free(pkey);
+    }
+    if (certificate)
+    {
+        pkcs11h_certificate_freeCertificate(certificate);
+    }
+    return ret;
+}
+#endif /* HAVE_XKEY_PROVIDER */
 
 int
 pkcs11_init_tls_session(pkcs11h_certificate_t certificate,
                         struct tls_root_ctx *const ssl_ctx)
 {
+
+#ifdef HAVE_XKEY_PROVIDER
+    return (xkey_load_from_pkcs11h(certificate, ssl_ctx) == 0); /* inverts the return value */
+#endif
+
     int ret = 1;
 
     X509 *x509 = NULL;

--- a/src/openvpn/ssl.c
+++ b/src/openvpn/ssl.c
@@ -604,6 +604,13 @@ init_ssl(const struct options *options, struct tls_root_ctx *new_ctx, bool in_ch
 
     tls_clear_error();
 
+#ifdef HAVE_XKEY_PROVIDER
+    if (key_is_external(options))
+    {
+        load_xkey_provider();
+    }
+#endif
+
     if (options->tls_server)
     {
         tls_ctx_server_new(new_ctx);

--- a/src/openvpn/ssl.c
+++ b/src/openvpn/ssl.c
@@ -604,12 +604,10 @@ init_ssl(const struct options *options, struct tls_root_ctx *new_ctx, bool in_ch
 
     tls_clear_error();
 
-#ifdef HAVE_XKEY_PROVIDER
     if (key_is_external(options))
     {
         load_xkey_provider();
     }
-#endif
 
     if (options->tls_server)
     {

--- a/src/openvpn/ssl.h
+++ b/src/openvpn/ssl.h
@@ -627,4 +627,10 @@ show_available_tls_ciphers(const char *cipher_list,
 bool
 tls_session_generate_data_channel_keys(struct tls_session *session);
 
+/**
+ * Load ovpn.xkey provider used for external key signing
+ */
+void
+load_xkey_provider(void);
+
 #endif /* ifndef OPENVPN_SSL_H */

--- a/src/openvpn/ssl_mbedtls.c
+++ b/src/openvpn/ssl_mbedtls.c
@@ -1551,4 +1551,10 @@ get_ssl_library_version(void)
     return mbedtls_version;
 }
 
+void
+load_xkey_provider(void)
+{
+    return; /* no external key provider in mbedTLS build */
+}
+
 #endif /* defined(ENABLE_CRYPTO_MBEDTLS) */

--- a/src/openvpn/ssl_openssl.c
+++ b/src/openvpn/ssl_openssl.c
@@ -70,7 +70,7 @@
 #include <openssl/applink.c>
 #endif
 
-static OSSL_LIB_CTX *tls_libctx;
+OSSL_LIB_CTX *tls_libctx; /* Global */
 
 static void unload_xkey_provider(void);
 

--- a/src/openvpn/ssl_openssl.c
+++ b/src/openvpn/ssl_openssl.c
@@ -1165,7 +1165,7 @@ end:
 }
 
 
-#ifdef ENABLE_MANAGEMENT
+#if defined(ENABLE_MANAGEMENT) && !defined(HAVE_XKEY_PROVIDER)
 
 /* encrypt */
 static int
@@ -1466,7 +1466,9 @@ err:
     return 0;
 }
 #endif /* OPENSSL_VERSION_NUMBER > 1.1.0 dev && !defined(OPENSSL_NO_EC) */
+#endif /* ENABLE_MANAGEMENT && !HAVE_XKEY_PROVIDER */
 
+#ifdef ENABLE_MANAGEMENT
 int
 tls_ctx_use_management_external_key(struct tls_root_ctx *ctx)
 {

--- a/src/openvpn/ssl_openssl.c
+++ b/src/openvpn/ssl_openssl.c
@@ -1482,6 +1482,15 @@ tls_ctx_use_management_external_key(struct tls_root_ctx *ctx)
     EVP_PKEY *pkey = X509_get0_pubkey(cert);
     ASSERT(pkey); /* NULL before SSL_CTX_use_certificate() is called */
 
+#ifdef HAVE_XKEY_PROVIDER
+    EVP_PKEY *privkey = xkey_load_management_key(tls_libctx, pkey);
+    if (!privkey
+        || !SSL_CTX_use_PrivateKey(ctx->ctx, privkey))
+    {
+        goto cleanup;
+    }
+    EVP_PKEY_free(privkey);
+#else
     if (EVP_PKEY_id(pkey) == EVP_PKEY_RSA)
     {
         if (!tls_ctx_use_external_rsa_key(ctx, pkey))
@@ -1509,6 +1518,8 @@ tls_ctx_use_management_external_key(struct tls_root_ctx *ctx)
         goto cleanup;
     }
 #endif /* OPENSSL_VERSION_NUMBER > 1.1.0 dev && !defined(OPENSSL_NO_EC) */
+
+#endif /* HAVE_XKEY_PROVIDER */
 
     ret = 0;
 cleanup:

--- a/src/openvpn/ssl_openssl.c
+++ b/src/openvpn/ssl_openssl.c
@@ -45,6 +45,7 @@
 #include "ssl_common.h"
 #include "base64.h"
 #include "openssl_compat.h"
+#include "xkey_common.h"
 
 #ifdef ENABLE_CRYPTOAPI
 #include "cryptoapi.h"
@@ -68,6 +69,10 @@
 #if defined(_MSC_VER) && !defined(_M_ARM64)
 #include <openssl/applink.c>
 #endif
+
+static OSSL_LIB_CTX *tls_libctx;
+
+static void unload_xkey_provider(void);
 
 /*
  * Allocate space in SSL objects in which to store a struct tls_session
@@ -113,7 +118,7 @@ tls_ctx_server_new(struct tls_root_ctx *ctx)
 {
     ASSERT(NULL != ctx);
 
-    ctx->ctx = SSL_CTX_new(SSLv23_server_method());
+    ctx->ctx = SSL_CTX_new_ex(tls_libctx, NULL, SSLv23_server_method());
 
     if (ctx->ctx == NULL)
     {
@@ -131,7 +136,7 @@ tls_ctx_client_new(struct tls_root_ctx *ctx)
 {
     ASSERT(NULL != ctx);
 
-    ctx->ctx = SSL_CTX_new(SSLv23_client_method());
+    ctx->ctx = SSL_CTX_new_ex(tls_libctx, NULL, SSLv23_client_method());
 
     if (ctx->ctx == NULL)
     {
@@ -150,6 +155,7 @@ tls_ctx_free(struct tls_root_ctx *ctx)
     ASSERT(NULL != ctx);
     SSL_CTX_free(ctx->ctx);
     ctx->ctx = NULL;
+    unload_xkey_provider(); /* in case it is loaded */
 }
 
 bool
@@ -2280,6 +2286,89 @@ const char *
 get_ssl_library_version(void)
 {
     return OpenSSL_version(OPENSSL_VERSION);
+}
+
+
+/** Some helper routines for provider load/unload */
+#ifdef HAVE_XKEY_PROVIDER
+static int
+provider_load(OSSL_PROVIDER *prov, void *dest_libctx)
+{
+    const char *name = OSSL_PROVIDER_get0_name(prov);
+    OSSL_PROVIDER_load(dest_libctx, name);
+    return 1;
+}
+
+static int
+provider_unload(OSSL_PROVIDER *prov, void *unused)
+{
+    (void) unused;
+    OSSL_PROVIDER_unload(prov);
+    return 1;
+}
+#endif /* HAVE_XKEY_PROVIDER */
+
+/**
+ * Setup ovpn.xey provider for signing with external keys.
+ * It is loaded into a custom library context so as not to pollute
+ * the default context. Alternatively we could override any
+ * system-wide property query set on the default context. But we
+ * want to avoid that.
+ */
+void
+load_xkey_provider(void)
+{
+#ifdef HAVE_XKEY_PROVIDER
+
+    /* Make a new library context for use in TLS context */
+    if (!tls_libctx)
+    {
+        tls_libctx = OSSL_LIB_CTX_new();
+        check_malloc_return(tls_libctx);
+
+        /* Load all providers in default LIBCTX into this libctx.
+         * OpenSSL has a child libctx functionality to automate this,
+         * but currently that is usable only from within providers.
+         * So we do something close to it manually here.
+         */
+        OSSL_PROVIDER_do_all(NULL, provider_load, tls_libctx);
+    }
+
+    if (!OSSL_PROVIDER_available(tls_libctx, "ovpn.xkey"))
+    {
+        OSSL_PROVIDER_add_builtin(tls_libctx, "ovpn.xkey", xkey_provider_init);
+        if (!OSSL_PROVIDER_load(tls_libctx, "ovpn.xkey"))
+        {
+            msg(M_NONFATAL, "ERROR: failed loading external key provider: "
+                            "Signing with external keys will not work.");
+        }
+    }
+
+    /* We only implement minimal functionality in ovpn.xkey, so we do not want
+     * methods in xkey to be picked unless absolutely required (i.e, when the key
+     * is external). Ensure this by setting a default propquery for the custom
+     * libctx that unprefers, but does not forbid, ovpn.xkey. See also man page
+     * of "property" in OpenSSL 3.0.
+     */
+    EVP_set_default_properties(tls_libctx, "?provider!=ovpn.xkey");
+
+#endif /* HAVE_XKEY_PROVIDER */
+}
+
+/**
+ * Undo steps in load_xkey_provider
+ */
+static void
+unload_xkey_provider(void)
+{
+#ifdef HAVE_XKEY_PROVIDER
+    if (tls_libctx)
+    {
+        OSSL_PROVIDER_do_all(tls_libctx, provider_unload, NULL);
+        OSSL_LIB_CTX_free(tls_libctx);
+    }
+#endif /* HAVE_XKEY_PROVIDER */
+    tls_libctx = NULL;
 }
 
 #endif /* defined(ENABLE_CRYPTO_OPENSSL) */

--- a/src/openvpn/xkey_common.h
+++ b/src/openvpn/xkey_common.h
@@ -1,0 +1,43 @@
+/*
+ *  OpenVPN -- An application to securely tunnel IP networks
+ *             over a single TCP/UDP port, with support for SSL/TLS-based
+ *             session authentication and key exchange,
+ *             packet encryption, packet authentication, and
+ *             packet compression.
+ *
+ *  Copyright (C) 2021 Selva Nair <selva.nair@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by the
+ *  Free Software Foundation, either version 2 of the License,
+ *  or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef XKEY_COMMON_H_
+#define XKEY_COMMON_H_
+
+#ifdef HAVE_XKEY_PROVIDER
+
+#include <openssl/provider.h>
+#include <openssl/core_dispatch.h>
+
+/**
+ * Initialization function for OpenVPN external key provider for OpenSSL
+ * Follows the function signature of OSSL_PROVIDER init()
+ */
+OSSL_provider_init_fn xkey_provider_init;
+
+#define XKEY_PROV_PROPS "provider=ovpn.xkey"
+
+#endif /* HAVE_XKEY_PROVIDER */
+
+#endif /* XKEY_COMMON_H_ */

--- a/src/openvpn/xkey_common.h
+++ b/src/openvpn/xkey_common.h
@@ -26,7 +26,6 @@
 #define XKEY_COMMON_H_
 
 #ifdef HAVE_XKEY_PROVIDER
-
 #include <openssl/provider.h>
 #include <openssl/core_dispatch.h>
 

--- a/src/openvpn/xkey_common.h
+++ b/src/openvpn/xkey_common.h
@@ -80,6 +80,17 @@ typedef int (XKEY_EXTERNAL_SIGN_fn)(void *handle, unsigned char *sig, size_t *si
  */
 typedef void (XKEY_PRIVKEY_FREE_fn)(void *handle);
 
+/**
+ * Generate an encapsulated EVP_PKEY for management-external-key
+ *
+ * @param libctx library context in which xkey provider has been loaded
+ * @param pubkey corresponding pubkey in the default provider's context
+ *
+ * @returns a new EVP_PKEY in the provider's keymgmt context.
+ * The pubkey is up-refd if retained -- the caller can free it after return
+ */
+EVP_PKEY *xkey_load_management_key(OSSL_LIB_CTX *libctx, EVP_PKEY *pubkey);
+
 #endif /* HAVE_XKEY_PROVIDER */
 
 #endif /* XKEY_COMMON_H_ */

--- a/src/openvpn/xkey_common.h
+++ b/src/openvpn/xkey_common.h
@@ -38,6 +38,49 @@ OSSL_provider_init_fn xkey_provider_init;
 
 #define XKEY_PROV_PROPS "provider=ovpn.xkey"
 
+/**
+ * Stuct to encapsulate signature algorithm parameters to pass
+ * to sign operation.
+ */
+typedef struct {
+   const char *padmode; /* "pkcs1", "pss" or "none" */
+   const char *mdname;  /* "SHA256" or "SHA2-256" etc. */
+   const char *saltlen; /* "digest", "auto" or "max" */
+   const char *keytype; /* "EC" or "RSA" */
+   const char *op;      /* "Sign" or "DigestSign" */
+} XKEY_SIGALG;
+
+/**
+ * Callback for sign operation -- must be implemented for each backend and
+ * is used in xkey_signature_sign(), or set when loading the key.
+ * (custom key loading not yet implemented).
+ *
+ * @param handle opaque key handle provided by the backend -- could be null
+ *               or unused for management interface.
+ * @param sig    On return caller should fill this with the signature
+ * @param siglen On entry *siglen has max size of sig and on return must be
+ *               set to the actual size of the signature
+ * @param tbs    buffer to sign
+ * @param tbslen size of data in tbs buffer
+ * @sigalg       contains the signature algorithm parameters
+ *
+ * @returns 1 on success, 0 on error.
+ *
+ * The data in tbs is just the digest with no DigestInfo header added. This is
+ * unlike the deprecated RSA_sign callback which provides encoded digest.
+ * For RSA_PKCS1 signatures, the external signing function must encode the digest
+ * before signing. The digest algorithm used is passed in the sigalg structure.
+ */
+typedef int (XKEY_EXTERNAL_SIGN_fn)(void *handle, unsigned char *sig, size_t *siglen,
+                                 const unsigned char *tbs, size_t tbslen,
+                                 XKEY_SIGALG sigalg);
+/**
+ * Signature of private key free function callback used
+ * to free the opaque private key handle obtained from the
+ * backend. Not required for management-external-key.
+ */
+typedef void (XKEY_PRIVKEY_FREE_fn)(void *handle);
+
 #endif /* HAVE_XKEY_PROVIDER */
 
 #endif /* XKEY_COMMON_H_ */

--- a/src/openvpn/xkey_common.h
+++ b/src/openvpn/xkey_common.h
@@ -25,7 +25,10 @@
 #ifndef XKEY_COMMON_H_
 #define XKEY_COMMON_H_
 
-#ifdef HAVE_XKEY_PROVIDER
+#include <openssl/opensslv.h>
+#if OPENSSL_VERSION_NUMBER >= 0x30000010L && !defined(DISABLE_XKEY_PROVIDER)
+#define HAVE_XKEY_PROVIDER 1
+
 #include <openssl/provider.h>
 #include <openssl/core_dispatch.h>
 

--- a/src/openvpn/xkey_common.h
+++ b/src/openvpn/xkey_common.h
@@ -114,6 +114,41 @@ bool
 encode_pkcs1(unsigned char *enc, size_t *enc_len, const char *mdname,
              const unsigned char *tbs, size_t tbslen);
 
+/**
+ * Compute message digest
+ *
+ * @param src           pointer to message to be hashed
+ * @param srclen        length of data in bytes
+ * @param buf           pointer to output buffer
+ * @param buflen        *buflen = capacity in bytes of output buffer
+ * @param mdname        name of the hash algorithm (SHA256, SHA1 etc.)
+ *
+ * @return              false on error, true  on success
+ *
+ * On successful return *buflen is set to the actual size of the result.
+ * TIP: EVP_MD_MAX_SIZE should be enough capacity of buf for al algorithms.
+ */
+int
+xkey_digest(const unsigned char *src, size_t srclen, unsigned char *buf,
+            size_t *buflen, const char *mdname);
+
+/**
+ * Load a generic external key with custom sign and free ops
+ *
+ * @param libctx    library context in which xkey provider has been loaded
+ * @param handle    an opaque handle to the backend -- passed to alll callbacks
+ * @param pubkey    corresponding pubkey in the default provider's context
+ * @param sign_op   private key signature operation to callback
+ * @param sign_op   private key signature operation to callback
+ *
+ * @returns a new EVP_PKEY in the provider's keymgmt context.
+ * IMPORTANT: a reference to the handle is retained by the provider and
+ * relased by callng free_op. The caller should not free it.
+ */
+EVP_PKEY *
+xkey_load_generic_key(OSSL_LIB_CTX *libctx, void *handle, EVP_PKEY *pubkey,
+                      XKEY_EXTERNAL_SIGN_fn sign_op, XKEY_PRIVKEY_FREE_fn free_op);
+
 #endif /* HAVE_XKEY_PROVIDER */
 
 #endif /* XKEY_COMMON_H_ */

--- a/src/openvpn/xkey_common.h
+++ b/src/openvpn/xkey_common.h
@@ -45,11 +45,11 @@ OSSL_provider_init_fn xkey_provider_init;
  * to sign operation.
  */
 typedef struct {
-   const char *padmode; /* "pkcs1", "pss" or "none" */
-   const char *mdname;  /* "SHA256" or "SHA2-256" etc. */
-   const char *saltlen; /* "digest", "auto" or "max" */
-   const char *keytype; /* "EC" or "RSA" */
-   const char *op;      /* "Sign" or "DigestSign" */
+   const char *padmode; /**< "pkcs1", "pss" or "none" */
+   const char *mdname;  /**< "SHA256" or "SHA2-256" etc. */
+   const char *saltlen; /**< "digest", "auto" or "max" */
+   const char *keytype; /**< "EC" or "RSA" */
+   const char *op;      /**< "Sign" or "DigestSign" */
 } XKEY_SIGALG;
 
 /**

--- a/src/openvpn/xkey_common.h
+++ b/src/openvpn/xkey_common.h
@@ -65,10 +65,13 @@ typedef struct {
  *
  * @returns 1 on success, 0 on error.
  *
- * The data in tbs is just the digest with no DigestInfo header added. This is
+ * If sigalg.op = "Sign", the data in tbs is the digest. If sigalg.op = "DigestSign"
+ * it is the message that the backend should hash wih appropriate hash algorithm before
+ * signing. In the former case no DigestInfo header is added to tbs. This is
  * unlike the deprecated RSA_sign callback which provides encoded digest.
  * For RSA_PKCS1 signatures, the external signing function must encode the digest
- * before signing. The digest algorithm used is passed in the sigalg structure.
+ * before signing. The digest algorithm used (or to be used) is passed in the sigalg
+ * structure.
  */
 typedef int (XKEY_EXTERNAL_SIGN_fn)(void *handle, unsigned char *sig, size_t *siglen,
                                  const unsigned char *tbs, size_t tbslen,

--- a/src/openvpn/xkey_common.h
+++ b/src/openvpn/xkey_common.h
@@ -94,6 +94,26 @@ typedef void (XKEY_PRIVKEY_FREE_fn)(void *handle);
  */
 EVP_PKEY *xkey_load_management_key(OSSL_LIB_CTX *libctx, EVP_PKEY *pubkey);
 
+/**
+ * Add PKCS1 DigestInfo to tbs and return the result in *enc.
+ *
+ * @param enc           pointer to output buffer
+ * @param enc_len       capacity in bytes of output buffer
+ * @param mdname        name of the hash algorithm (SHA256, SHA1 etc.)
+ * @param tbs           pointer to digest to be encoded
+ * @param tbslen        length of data in bytes
+ *
+ * @return              false on error, true  on success
+ *
+ * On return enc_len is  set to actual size of the result.
+ * enc is NULL or enc_len is not enough to store the result, it is set
+ * to the required size and false is returned.
+ *
+ */
+bool
+encode_pkcs1(unsigned char *enc, size_t *enc_len, const char *mdname,
+             const unsigned char *tbs, size_t tbslen);
+
 #endif /* HAVE_XKEY_PROVIDER */
 
 #endif /* XKEY_COMMON_H_ */

--- a/src/openvpn/xkey_common.h
+++ b/src/openvpn/xkey_common.h
@@ -149,6 +149,8 @@ EVP_PKEY *
 xkey_load_generic_key(OSSL_LIB_CTX *libctx, void *handle, EVP_PKEY *pubkey,
                       XKEY_EXTERNAL_SIGN_fn sign_op, XKEY_PRIVKEY_FREE_fn free_op);
 
+extern OSSL_LIB_CTX *tls_libctx; /* Global */
+
 #endif /* HAVE_XKEY_PROVIDER */
 
 #endif /* XKEY_COMMON_H_ */

--- a/src/openvpn/xkey_helper.c
+++ b/src/openvpn/xkey_helper.c
@@ -28,14 +28,14 @@
 #include "config-msvc.h"
 #endif
 
-#ifdef HAVE_XKEY_PROVIDER
-
 #include "syshead.h"
 #include "error.h"
 #include "buffer.h"
 #include "xkey_common.h"
 #include "manage.h"
 #include "base64.h"
+
+#ifdef HAVE_XKEY_PROVIDER
 
 #include <openssl/provider.h>
 #include <openssl/params.h>

--- a/src/openvpn/xkey_helper.c
+++ b/src/openvpn/xkey_helper.c
@@ -34,6 +34,8 @@
 #include "error.h"
 #include "buffer.h"
 #include "xkey_common.h"
+#include "manage.h"
+#include "base64.h"
 
 #include <openssl/provider.h>
 #include <openssl/params.h>
@@ -47,6 +49,31 @@
 static const char *const props = XKEY_PROV_PROPS;
 
 XKEY_EXTERNAL_SIGN_fn xkey_management_sign;
+
+/** helper to compute digest */
+static int
+xkey_digest(const unsigned char *src, size_t srclen, unsigned char *buf,
+            size_t *buflen, const char *mdname)
+{
+    dmsg(D_LOW, "In xkey_digest");
+    EVP_MD *md = EVP_MD_fetch(NULL, mdname, NULL); /* from default context */
+    if (!md)
+    {
+        msg(M_WARN, "WARN: xkey_digest: MD_fetch failed for <%s>", mdname);
+        return 0;
+    }
+
+    unsigned int len = (unsigned int) *buflen;
+    if (EVP_Digest(src, srclen, buf, &len, md, NULL) != 1)
+    {
+        msg(M_WARN, "WARN: xkey_digest: EVP_Digest failed");
+        return 0;
+    }
+    EVP_MD_free(md);
+
+    *buflen = len;
+    return 1;
+}
 
 /**
  * Load external key for signing via management interface.
@@ -94,13 +121,88 @@ xkey_load_management_key(OSSL_LIB_CTX *libctx, EVP_PKEY *pubkey)
     return pkey;
 }
 
-/* not yet implemented */
+/**
+ * Signature callback for xkey_provider with management-external-key
+ *
+ * @param handle        Unused -- may be null
+ * @param sig           On successful return signature is in sig.
+ * @param siglen        On entry *siglen has length of buffer sig,
+ *                      on successful return size of signature
+ * @param tbs           hash or message to be signed
+ * @param tbslen        len of data in dgst
+ * @param sigalg        extra signature parameters
+ *
+ * @return              signature length or -1 on error.
+ */
 int
 xkey_management_sign(void *unused, unsigned char *sig, size_t *siglen,
                      const unsigned char *tbs, size_t tbslen, XKEY_SIGALG alg)
 {
-    msg(M_FATAL, "FATAL ERROR: A sign callback for this key is not implemented.");
-    return 0;
+    (void) unused;
+    char alg_str[128];
+    unsigned char buf[EVP_MAX_MD_SIZE]; /* for computing digest if required */
+    size_t buflen = sizeof(buf);
+
+    if (!strcmp(alg.op, "DigestSign"))
+    {
+        dmsg(D_LOW, "xkey_management_sign: computing digest");
+        if (xkey_digest(tbs, tbslen, buf, &buflen, alg.mdname))
+        {
+            tbs = buf;
+            tbslen = buflen;
+            alg.op = "Sign";
+        }
+        else
+        {
+            return 0;
+        }
+    }
+
+    if (!strcmp(alg.keytype, "EC"))
+    {
+        strncpynt(alg_str, "ECDSA", sizeof(alg_str));
+    }
+    /* else assume RSA key */
+    else if (!strcmp(alg.padmode, "pkcs1"))
+    {
+        strncpynt(alg_str, "RSA_PKCS1_PADDING", sizeof(alg_str));
+    }
+    else if (!strcmp(alg.padmode, "none"))
+    {
+        strncpynt(alg_str, "RSA_NO_PADDING", sizeof(alg_str));
+    }
+    else if (!strcmp(alg.padmode, "pss"))
+    {
+        openvpn_snprintf(alg_str, sizeof(alg_str), "%s,hashalg=%s,saltlen=%s",
+                       "RSA_PKCS1_PSS_PADDING", alg.mdname,alg.saltlen);
+    }
+    else {
+        msg(M_NONFATAL, "Unsupported RSA padding mode in signature request<%s>",
+            alg.padmode);
+        return 0;
+    }
+    dmsg(D_LOW, "xkey management_sign: requesting sig with algorithm <%s>", alg_str);
+
+    char *in_b64 = NULL;
+    char *out_b64 = NULL;
+    int len = -1;
+
+    int bencret = openvpn_base64_encode(tbs, (int) tbslen, &in_b64);
+
+    if (management && bencret > 0)
+    {
+        out_b64 = management_query_pk_sig(management, in_b64, alg_str);
+    }
+    if (out_b64)
+    {
+        len = openvpn_base64_decode(out_b64, sig, (int) *siglen);
+    }
+    free(in_b64);
+    free(out_b64);
+
+    *siglen = (len > 0) ? len : 0;
+
+    return (*siglen > 0);
 }
 
 #endif /* HAVE_XKEY_PROVIDER */

--- a/src/openvpn/xkey_helper.c
+++ b/src/openvpn/xkey_helper.c
@@ -1,0 +1,106 @@
+/*
+ *  OpenVPN -- An application to securely tunnel IP networks
+ *             over a single TCP/UDP port, with support for SSL/TLS-based
+ *             session authentication and key exchange,
+ *             packet encryption, packet authentication, and
+ *             packet compression.
+ *
+ *  Copyright (C) 2021 Selva Nair <selva.nair@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by the
+ *  Free Software Foundation, either version 2 of the License,
+ *  or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#elif defined(_MSC_VER)
+#include "config-msvc.h"
+#endif
+
+#ifdef HAVE_XKEY_PROVIDER
+
+#include "syshead.h"
+#include "error.h"
+#include "buffer.h"
+#include "xkey_common.h"
+
+#include <openssl/provider.h>
+#include <openssl/params.h>
+#include <openssl/core_dispatch.h>
+#include <openssl/core_object.h>
+#include <openssl/core_names.h>
+#include <openssl/store.h>
+#include <openssl/evp.h>
+#include <openssl/err.h>
+
+static const char *const props = XKEY_PROV_PROPS;
+
+XKEY_EXTERNAL_SIGN_fn xkey_management_sign;
+
+/**
+ * Load external key for signing via management interface.
+ * The public key must be passed in by the caller as we may not
+ * be able to get it from the management.
+ * Returns an EVP_PKEY object attached to xkey provider.
+ * Caller must free it when no longer needed.
+ */
+EVP_PKEY *
+xkey_load_management_key(OSSL_LIB_CTX *libctx, EVP_PKEY *pubkey)
+{
+    EVP_PKEY *pkey = NULL;
+    ASSERT(pubkey);
+
+    /* Management interface doesnt require any handle to be
+     * stored in the key. We use a dummy pointer as we do need a
+     * non-NULL value to indicate private key is avaialble.
+     */
+    void *dummy = & "dummy";
+
+    const char *origin = "management";
+    XKEY_EXTERNAL_SIGN_fn *sign_op = xkey_management_sign;
+
+    /* UTF8 string pointers in here are only read from, so cast is safe */
+    OSSL_PARAM params[] = {
+        {"xkey-origin", OSSL_PARAM_UTF8_STRING, (char *) origin, 0, 0},
+        {"pubkey", OSSL_PARAM_OCTET_STRING, &pubkey, sizeof(pubkey), 0},
+        {"handle", OSSL_PARAM_OCTET_PTR, &dummy, sizeof(dummy), 0},
+        {"sign_op", OSSL_PARAM_OCTET_PTR, (void **) &sign_op, sizeof(sign_op), 0},
+        {NULL, 0, NULL, 0, 0}};
+
+    /* Do not use EVP_PKEY_new_from_pkey as that will take keymgmt from pubkey */
+    EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new_from_name(libctx, EVP_PKEY_get0_type_name(pubkey), props);
+    if (!ctx
+        || EVP_PKEY_fromdata_init(ctx) != 1
+        || EVP_PKEY_fromdata(ctx, &pkey, EVP_PKEY_KEYPAIR, params) != 1)
+    {
+        msg(M_NONFATAL, "Error loading key into ovpn.xkey provider");
+    }
+    if (ctx)
+    {
+        EVP_PKEY_CTX_free(ctx);
+    }
+
+    return pkey;
+}
+
+/* not yet implemented */
+int
+xkey_management_sign(void *unused, unsigned char *sig, size_t *siglen,
+                     const unsigned char *tbs, size_t tbslen, XKEY_SIGALG alg)
+{
+    msg(M_FATAL, "FATAL ERROR: A sign callback for this key is not implemented.");
+    return 0;
+}
+
+#endif /* HAVE_XKEY_PROVIDER */

--- a/src/openvpn/xkey_provider.c
+++ b/src/openvpn/xkey_provider.c
@@ -79,6 +79,13 @@ typedef enum
  *
  * We also keep the public key in the form of a native OpenSSL EVP_PKEY.
  * This allows us to do all public ops by calling ops in the default provider.
+ * Both these are references retained by us and freed when the key is
+ * destroyed. As the pubkey is native, we free it using EVP_PKEY_free().
+ * To free the handle we call the backend if a free function
+ * has been set for that key. It could be set when the key is
+ * created/imported.
+ * For native keys, there is no need to free the handle as its either
+ * NULL of the same as the pubkey which we always free.
  */
 typedef struct
 {
@@ -125,6 +132,9 @@ static OSSL_FUNC_keymgmt_set_params_fn keymgmt_set_params;
 static OSSL_FUNC_keymgmt_query_operation_name_fn rsa_keymgmt_name;
 static OSSL_FUNC_keymgmt_query_operation_name_fn ec_keymgmt_name;
 
+static int
+keymgmt_import_helper(XKEY_KEYDATA *key, const OSSL_PARAM params[]);
+
 static XKEY_KEYDATA *
 keydata_new()
 {
@@ -147,6 +157,11 @@ keydata_free(XKEY_KEYDATA *key)
     if (!key || key->refcount-- > 0) /* free when refcount goes to zero */
     {
         return;
+    }
+    if (key->free && key->handle)
+    {
+        key->free(key->handle);
+        key->handle = NULL;
     }
     if (key->pubkey)
     {
@@ -187,7 +202,27 @@ keymgmt_load(const void *reference, size_t reference_sz)
  * appropriate for the key. We just use it to create a native
  * EVP_PKEY from params and assign to keydata->handle.
  *
- * Import of external keys -- to be implemented
+ * For non-native keys the params[] array should include a custom
+ * value with name "xkey-origin".
+ *
+ * Other required parameters in the params array are:
+ *
+ *  pubkey - pointer to native public key as a OCTET_STRING
+ *           the public key is duplicated on receipt
+ *  handle - reference to opaque handle to private key -- if not required
+ *           pass a dummy value that is not zero. type = OCTET_PTR
+ *           The reference is retained -- caller must _not_ free it.
+ *  sign_op - function pointer for sign operation. type = OCTET_PTR
+ *            Must be a reference to XKEY_EXTERNAL_SIGN_fn
+ *  xkey-origin - A custom string to indicate the external key origin. UTF8_STRING
+ *                The value doesn't really matter, but must be present.
+ *
+ * Optional params
+ *  free_op - Called as free(handle) when the key is deleted. If the
+ *           handle should not be freed, do not include. type = OCTET_PTR
+ *           Must be a reference to XKEY_PRIVKEY_FREE_fn
+ *
+ *  See xkey_load_management_key for an example use.
  */
 static int
 keymgmt_import(void *keydata, int selection, const OSSL_PARAM params[], const char *name)
@@ -204,6 +239,17 @@ keymgmt_import(void *keydata, int selection, const OSSL_PARAM params[], const ch
         msg(M_WARN, "Error: keymgmt_import: keydata not empty -- our keys are immutable");
         return 0;
     }
+
+    /* if params contain a custom origin, call our helper to import custom keys */
+    const OSSL_PARAM *p = OSSL_PARAM_locate_const(params, "xkey-origin");
+    if (p && p->data_type == OSSL_PARAM_UTF8_STRING)
+    {
+        key->origin = EXTERNAL_KEY;
+        xkey_dmsg(D_LOW, "importing external key");
+        return keymgmt_import_helper(key, params);
+    }
+
+    xkey_dmsg(D_LOW, "importing native key");
 
     /* create a native public key and assign it to key->pubkey */
     EVP_PKEY *pkey = NULL;
@@ -359,10 +405,95 @@ keymgmt_get_params(void *keydata, OSSL_PARAM *params)
     return EVP_PKEY_get_params(key->pubkey, params);
 }
 
+/* Helper used by keymgmt_import and keymgmt_set_params
+ * for our keys. Not to be used for OpenSSL native keys.
+ */
+static int
+keymgmt_import_helper(XKEY_KEYDATA *key, const OSSL_PARAM *params)
+{
+    xkey_dmsg(D_LOW, "entry");
+
+    const OSSL_PARAM *p;
+    EVP_PKEY *pkey = NULL;
+
+    ASSERT(key);
+    /* calling this with native keys is a coding error */
+    ASSERT(key->origin != OPENSSL_NATIVE);
+
+    if (params == NULL)
+    {
+        return 1; /* not an error */
+    }
+
+    /* our keys are immutable, we do not allow resetting parameters */
+    if (key->pubkey)
+    {
+        return 0;
+    }
+
+    /* only check params we understand and ignore the rest */
+
+    p = OSSL_PARAM_locate_const(params, "pubkey"); /*setting pubkey on our keydata */
+    if (p && p->data_type == OSSL_PARAM_OCTET_STRING
+        && p->data_size == sizeof(pkey))
+    {
+        pkey = *(EVP_PKEY **)p->data;
+        ASSERT(pkey);
+
+        int id = EVP_PKEY_get_id(pkey);
+        if (id != EVP_PKEY_RSA && id != EVP_PKEY_EC)
+        {
+            msg(M_WARN, "Error: xkey keymgmt_import: unknown key type (%d)", id);
+            return 0;
+        }
+
+        key->pubkey = EVP_PKEY_dup(pkey);
+        if (key->pubkey == NULL)
+        {
+            msg(M_NONFATAL, "Error: xkey keymgmt_import: duplicating pubkey failed.");
+            return 0;
+        }
+    }
+
+    p = OSSL_PARAM_locate_const(params, "handle"); /*setting privkey */
+    if (p && p->data_type == OSSL_PARAM_OCTET_PTR
+        && p->data_size == sizeof(key->handle))
+    {
+        key->handle = *(void **)p->data;
+        /* caller should keep the reference alive until we call free */
+        ASSERT(key->handle); /* fix your params array */
+    }
+
+    p = OSSL_PARAM_locate_const(params, "sign_op"); /*setting sign_op */
+    if (p && p->data_type == OSSL_PARAM_OCTET_PTR
+        && p->data_size == sizeof(key->sign))
+    {
+        key->sign = *(void **)p->data;
+        ASSERT(key->sign); /* fix your params array */
+    }
+
+    /* optional parameters */
+    p = OSSL_PARAM_locate_const(params, "free_op"); /*setting free_op */
+    if (p && p->data_type == OSSL_PARAM_OCTET_PTR
+        && p->data_size == sizeof(key->free))
+    {
+        key->free = *(void **)p->data;
+    }
+    xkey_dmsg(D_LOW, "imported external %s key", EVP_PKEY_get0_type_name(key->pubkey));
+
+    return 1;
+}
+
 /**
+ * Set params on a key.
+ *
  * If the key is an encapsulated native key, we just call
  * EVP_PKEY_set_params in the default context. Only those params
  * supported by the default provider would work in this case.
+ *
+ * We treat our key object as immutable, so this works only with an
+ * empty key. Supported params for external keys are the
+ * same as those listed in the description of keymgmt_import.
  */
 static int
 keymgmt_set_params(void *keydata, const OSSL_PARAM *params)
@@ -374,7 +505,7 @@ keymgmt_set_params(void *keydata, const OSSL_PARAM *params)
 
     if (key->origin != OPENSSL_NATIVE)
     {
-        return 0; /* to be implemented */
+        return keymgmt_import_helper(key, params);
     }
     else if (key->handle == NULL) /* once handle is set our key is immutable */
     {

--- a/src/openvpn/xkey_provider.c
+++ b/src/openvpn/xkey_provider.c
@@ -44,6 +44,9 @@
 #include <openssl/evp.h>
 #include <openssl/err.h>
 
+/* propq set all on all ops we implement */
+static const char *const props = XKEY_PROV_PROPS;
+
 /* A descriptive name */
 static const char *provname = "OpenVPN External Key Provider";
 
@@ -59,6 +62,373 @@ typedef struct
               dmsg(f|M_NOLF, "xkey_provider: In %s: ", __func__);    \
               dmsg(f|M_NOPREFIX, __VA_ARGS__);                      \
            } while(0)
+
+typedef enum
+{
+    ORIGIN_NONAME = 0,
+    OPENSSL_NATIVE, /* native key imported in */
+    EXTERNAL_KEY
+} XKEY_ORIGIN;
+
+/*
+ * XKEY_KEYDATA: Our keydata encapsulation:
+ * ---------------------------------------
+ * We keep an opaque handle provided by the backend for the loaded
+ * key. It's passed back to the backend for any operation on private
+ * keys --- in practice, sign() op only.
+ *
+ * We also keep the public key in the form of a native OpenSSL EVP_PKEY.
+ * This allows us to do all public ops by calling ops in the default provider.
+ */
+typedef struct
+{
+    /* opaque handle dependent on KEY_ORIGIN -- could be NULL */
+    void *handle;
+    /* associated public key as an openvpn native key */
+    EVP_PKEY *pubkey;
+    /* origin of key -- native or external */
+    XKEY_ORIGIN origin;
+    XKEY_PROVIDER_CTX *prov;
+    int refcount;                /* reference count */
+} XKEY_KEYDATA;
+
+#define KEYTYPE(key) ((key)->pubkey ? EVP_PKEY_get_id((key)->pubkey) : 0)
+#define KEYSIZE(key) ((key)->pubkey ? EVP_PKEY_get_size((key)->pubkey) : 0)
+
+/* keymgmt provider */
+
+/* keymgmt callbacks we implement */
+static OSSL_FUNC_keymgmt_new_fn keymgmt_new;
+static OSSL_FUNC_keymgmt_free_fn keymgmt_free;
+static OSSL_FUNC_keymgmt_load_fn keymgmt_load;
+static OSSL_FUNC_keymgmt_has_fn keymgmt_has;
+static OSSL_FUNC_keymgmt_match_fn keymgmt_match;
+static OSSL_FUNC_keymgmt_import_fn rsa_keymgmt_import;
+static OSSL_FUNC_keymgmt_import_fn ec_keymgmt_import;
+static OSSL_FUNC_keymgmt_import_types_fn keymgmt_import_types;
+static OSSL_FUNC_keymgmt_get_params_fn keymgmt_get_params;
+static OSSL_FUNC_keymgmt_gettable_params_fn keymgmt_gettable_params;
+static OSSL_FUNC_keymgmt_set_params_fn keymgmt_set_params;
+static OSSL_FUNC_keymgmt_query_operation_name_fn rsa_keymgmt_name;
+static OSSL_FUNC_keymgmt_query_operation_name_fn ec_keymgmt_name;
+
+static XKEY_KEYDATA *
+keydata_new()
+{
+    xkey_dmsg(D_LOW, "entry");
+
+    XKEY_KEYDATA *key = calloc(sizeof(*key), 1);
+    if (!key)
+    {
+        msg(M_NONFATAL, "xkey_keydata_new: out of memory");
+    }
+
+    return key;
+}
+
+static void
+keydata_free(XKEY_KEYDATA *key)
+{
+    xkey_dmsg(D_LOW, "entry");
+
+    if (!key || key->refcount-- > 0) /* free when refcount goes to zero */
+    {
+        return;
+    }
+    if (key->pubkey)
+    {
+        EVP_PKEY_free(key->pubkey);
+    }
+    free(key);
+}
+
+static void *
+keymgmt_new(void *provctx)
+{
+    xkey_dmsg(D_LOW, "entry");
+
+    XKEY_KEYDATA *key = keydata_new();
+    if (key)
+    {
+        key->prov = provctx;
+    }
+
+    return key;
+}
+
+static void *
+keymgmt_load(const void *reference, size_t reference_sz)
+{
+    xkey_dmsg(D_LOW, "entry");
+
+    return NULL;
+}
+
+/**
+ * Key import function
+ * When key operations like sign/verify are done in our context
+ * the key gets imported into us. We will also use import to
+ * load an external key into the provider.
+ *
+ * For native keys we get called with standard OpenSSL params
+ * appropriate for the key. We just use it to create a native
+ * EVP_PKEY from params and assign to keydata->handle.
+ *
+ * Import of external keys -- to be implemented
+ */
+static int
+keymgmt_import(void *keydata, int selection, const OSSL_PARAM params[], const char *name)
+{
+    xkey_dmsg(D_LOW, "entry");
+
+    XKEY_KEYDATA *key = keydata;
+    ASSERT(key);
+
+    /* Our private key is immutable -- we import only if keydata is empty */
+
+    if (key->handle || key->pubkey)
+    {
+        msg(M_WARN, "Error: keymgmt_import: keydata not empty -- our keys are immutable");
+        return 0;
+    }
+
+    /* create a native public key and assign it to key->pubkey */
+    EVP_PKEY *pkey = NULL;
+
+    EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new_from_name(key->prov->libctx, name, NULL);
+    if (!ctx
+        || (EVP_PKEY_fromdata_init(ctx) != 1)
+        || (EVP_PKEY_fromdata(ctx, &pkey, selection, (OSSL_PARAM*) params) !=1))
+    {
+        msg(M_WARN, "Error: keymgmt_import failed for key type <%s>", name);
+        if (pkey)
+        {
+            EVP_PKEY_free(pkey);
+        }
+        if (ctx)
+        {
+            EVP_PKEY_CTX_free(ctx);
+        }
+        return 0;
+    }
+    EVP_PKEY_CTX_free(ctx);
+
+    key->pubkey = pkey;
+    key->origin = OPENSSL_NATIVE;
+    if (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY)
+    {
+        /* just use the same key as handle -- do not up-ref */
+        key->handle = pkey;
+    }
+
+    xkey_dmsg(D_LOW, "imported native %s key", EVP_PKEY_get0_type_name(pkey));
+    return 1;
+}
+
+static int
+rsa_keymgmt_import(void *keydata, int selection, const OSSL_PARAM params[])
+{
+    xkey_dmsg(D_LOW, "entry");
+
+    return keymgmt_import(keydata, selection, params, "RSA");
+}
+
+static int
+ec_keymgmt_import(void *keydata, int selection, const OSSL_PARAM params[])
+{
+    xkey_dmsg(D_LOW, "entry");
+
+    return keymgmt_import(keydata, selection, params, "EC");
+}
+
+/* This function has to exist for key import to work
+ * though we do not support import of individual params
+ * like n or e. We simply return an empty list here for
+ * both rsa and ec, which works.
+ */
+static const OSSL_PARAM *
+keymgmt_import_types(int selection)
+{
+    xkey_dmsg(D_LOW, "entry");
+
+    static const OSSL_PARAM key_types[] = { OSSL_PARAM_END };
+
+    if (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY)
+    {
+       return key_types;
+    }
+    return NULL;
+}
+
+/* We do not support any key export */
+
+static void
+keymgmt_free(void *keydata)
+{
+    xkey_dmsg(D_LOW, "entry");
+
+    keydata_free(keydata);
+}
+
+static int
+keymgmt_has(const void *keydata, int selection)
+{
+    xkey_dmsg(D_LOW, "selection = %d", selection);
+
+    const XKEY_KEYDATA *key = keydata;
+    int ok = (key != NULL);
+
+    if (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY)
+    {
+        ok = ok && key->pubkey;
+    }
+    if (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY)
+    {
+        ok = ok && key->handle;
+    }
+
+    return ok;
+}
+
+static int
+keymgmt_match(const void *keydata1, const void *keydata2, int selection)
+{
+    const XKEY_KEYDATA *key1 = keydata1;
+    const XKEY_KEYDATA *key2 = keydata2;
+
+    xkey_dmsg(D_LOW, "entry");
+
+    int ret = key1 && key2 && key1->pubkey && key2->pubkey;
+
+    /* our keys always have pubkey -- we only match them */
+
+    if (selection & OSSL_KEYMGMT_SELECT_KEYPAIR)
+    {
+        ret = ret && EVP_PKEY_eq(key1->pubkey, key2->pubkey);
+        xkey_dmsg(D_LOW, "checking key pair match: res = %d", ret);
+    }
+
+    if (selection & OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS)
+    {
+        ret = ret && EVP_PKEY_parameters_eq(key1->pubkey, key2->pubkey);
+        xkey_dmsg(D_LOW, "checking parameter match: res = %d", ret);
+    }
+
+    return ret;
+}
+
+/* A minimal set of key params that we can return */
+static const OSSL_PARAM *
+keymgmt_gettable_params(void *provctx)
+{
+    xkey_dmsg(D_LOW, "entry");
+
+    static OSSL_PARAM gettable[] = {
+        OSSL_PARAM_int(OSSL_PKEY_PARAM_BITS, NULL),
+        OSSL_PARAM_int(OSSL_PKEY_PARAM_SECURITY_BITS, NULL),
+        OSSL_PARAM_int(OSSL_PKEY_PARAM_MAX_SIZE, NULL),
+        OSSL_PARAM_END
+    };
+    return gettable;
+}
+
+static int
+keymgmt_get_params(void *keydata, OSSL_PARAM *params)
+{
+    xkey_dmsg(D_LOW, "entry");
+
+    XKEY_KEYDATA *key = keydata;
+    if (!key || !key->pubkey)
+    {
+        return 0;
+    }
+
+    return EVP_PKEY_get_params(key->pubkey, params);
+}
+
+/**
+ * If the key is an encapsulated native key, we just call
+ * EVP_PKEY_set_params in the default context. Only those params
+ * supported by the default provider would work in this case.
+ */
+static int
+keymgmt_set_params(void *keydata, const OSSL_PARAM *params)
+{
+    XKEY_KEYDATA *key = keydata;
+    ASSERT(key);
+
+    xkey_dmsg(D_LOW, "entry");
+
+    if (key->origin != OPENSSL_NATIVE)
+    {
+        return 0; /* to be implemented */
+    }
+    else if (key->handle == NULL) /* once handle is set our key is immutable */
+    {
+        /* pubkey is always native -- just delegate */
+        return EVP_PKEY_set_params(key->pubkey, (OSSL_PARAM *)params);
+    }
+    else
+    {
+        msg(M_WARN, "xkey keymgmt_set_params: key is immutable");
+    }
+    return 1;
+}
+
+static const char *
+rsa_keymgmt_name(int id)
+{
+    xkey_dmsg(D_LOW, "entry");
+
+    return "RSA";
+}
+
+static const char *
+ec_keymgmt_name(int id)
+{
+    xkey_dmsg(D_LOW, "entry");
+
+    return "EC";
+}
+
+static const OSSL_DISPATCH rsa_keymgmt_functions[] = {
+    {OSSL_FUNC_KEYMGMT_NEW, (void (*)(void)) keymgmt_new},
+    {OSSL_FUNC_KEYMGMT_FREE, (void (*)(void)) keymgmt_free},
+    {OSSL_FUNC_KEYMGMT_LOAD, (void (*)(void)) keymgmt_load},
+    {OSSL_FUNC_KEYMGMT_HAS, (void (*)(void)) keymgmt_has},
+    {OSSL_FUNC_KEYMGMT_MATCH, (void (*)(void)) keymgmt_match},
+    {OSSL_FUNC_KEYMGMT_IMPORT, (void (*)(void)) rsa_keymgmt_import},
+    {OSSL_FUNC_KEYMGMT_IMPORT_TYPES, (void (*)(void)) keymgmt_import_types},
+    {OSSL_FUNC_KEYMGMT_GETTABLE_PARAMS, (void (*) (void)) keymgmt_gettable_params},
+    {OSSL_FUNC_KEYMGMT_GET_PARAMS, (void (*) (void)) keymgmt_get_params},
+    {OSSL_FUNC_KEYMGMT_SET_PARAMS, (void (*) (void)) keymgmt_set_params},
+    {OSSL_FUNC_KEYMGMT_SETTABLE_PARAMS, (void (*) (void)) keymgmt_gettable_params}, /* same as gettable */
+    {OSSL_FUNC_KEYMGMT_QUERY_OPERATION_NAME, (void (*)(void)) rsa_keymgmt_name},
+    {0, NULL }
+};
+
+static const OSSL_DISPATCH ec_keymgmt_functions[] = {
+    {OSSL_FUNC_KEYMGMT_NEW, (void (*)(void)) keymgmt_new},
+    {OSSL_FUNC_KEYMGMT_FREE, (void (*)(void)) keymgmt_free},
+    {OSSL_FUNC_KEYMGMT_LOAD, (void (*)(void)) keymgmt_load},
+    {OSSL_FUNC_KEYMGMT_HAS, (void (*)(void)) keymgmt_has},
+    {OSSL_FUNC_KEYMGMT_MATCH, (void (*)(void)) keymgmt_match},
+    {OSSL_FUNC_KEYMGMT_IMPORT, (void (*)(void)) ec_keymgmt_import},
+    {OSSL_FUNC_KEYMGMT_IMPORT_TYPES, (void (*)(void)) keymgmt_import_types},
+    {OSSL_FUNC_KEYMGMT_GETTABLE_PARAMS, (void (*) (void)) keymgmt_gettable_params},
+    {OSSL_FUNC_KEYMGMT_GET_PARAMS, (void (*) (void)) keymgmt_get_params},
+    {OSSL_FUNC_KEYMGMT_SET_PARAMS, (void (*) (void)) keymgmt_set_params},
+    {OSSL_FUNC_KEYMGMT_SETTABLE_PARAMS, (void (*) (void)) keymgmt_gettable_params}, /* same as gettable */
+    {OSSL_FUNC_KEYMGMT_QUERY_OPERATION_NAME, (void (*)(void)) ec_keymgmt_name},
+    {0, NULL }
+};
+
+const OSSL_ALGORITHM keymgmts[] = {
+    {"RSA:rsaEncryption", props, rsa_keymgmt_functions, "OpenVPN xkey RSA Key Manager"},
+    {"RSA-PSS:RSASSA-PSS", props, rsa_keymgmt_functions, "OpenVPN xkey RSA-PSS Key Manager"},
+    {"EC:id-ecPublicKey", props, ec_keymgmt_functions, "OpenVPN xkey EC Key Manager"},
+    {NULL, NULL, NULL, NULL}
+};
 
 /* main provider interface */
 
@@ -81,7 +451,7 @@ query_operation(void *provctx, int op, int *no_store)
             return NULL;
 
         case OSSL_OP_KEYMGMT:
-            return NULL;
+            return keymgmts;
 
         default:
             xkey_dmsg(D_LOW, "op not supported");

--- a/src/openvpn/xkey_provider.c
+++ b/src/openvpn/xkey_provider.c
@@ -64,14 +64,14 @@ typedef struct
 
 typedef enum
 {
-    ORIGIN_NONAME = 0,
+    ORIGIN_UNDEFINED = 0,
     OPENSSL_NATIVE, /* native key imported in */
     EXTERNAL_KEY
 } XKEY_ORIGIN;
 
-/*
+/**
  * XKEY_KEYDATA: Our keydata encapsulation:
- * ---------------------------------------
+ *
  * We keep an opaque handle provided by the backend for the loaded
  * key. It's passed back to the backend for any operation on private
  * keys --- in practice, sign() op only.
@@ -139,7 +139,7 @@ keydata_new()
 {
     xkey_dmsg(D_LOW, "entry");
 
-    XKEY_KEYDATA *key = calloc(sizeof(*key), 1);
+    XKEY_KEYDATA *key = OPENSSL_zalloc(sizeof(*key));
     if (!key)
     {
         msg(M_NONFATAL, "xkey_keydata_new: out of memory");
@@ -166,7 +166,7 @@ keydata_free(XKEY_KEYDATA *key)
     {
         EVP_PKEY_free(key->pubkey);
     }
-    free(key);
+    OPENSSL_free(key);
 }
 
 static void *
@@ -232,7 +232,6 @@ keymgmt_import(void *keydata, int selection, const OSSL_PARAM params[], const ch
     ASSERT(key);
 
     /* Our private key is immutable -- we import only if keydata is empty */
-
     if (key->handle || key->pubkey)
     {
         msg(M_WARN, "Error: keymgmt_import: keydata not empty -- our keys are immutable");
@@ -317,8 +316,6 @@ keymgmt_import_types(int selection)
     }
     return NULL;
 }
-
-/* We do not support any key export */
 
 static void
 keymgmt_free(void *keydata)

--- a/src/openvpn/xkey_provider.c
+++ b/src/openvpn/xkey_provider.c
@@ -88,12 +88,25 @@ typedef struct
     EVP_PKEY *pubkey;
     /* origin of key -- native or external */
     XKEY_ORIGIN origin;
+    /* sign function in backend to call */
+    XKEY_EXTERNAL_SIGN_fn *sign;
+    /* keydata handle free function of backend */
+    XKEY_PRIVKEY_FREE_fn *free;
     XKEY_PROVIDER_CTX *prov;
     int refcount;                /* reference count */
 } XKEY_KEYDATA;
 
 #define KEYTYPE(key) ((key)->pubkey ? EVP_PKEY_get_id((key)->pubkey) : 0)
 #define KEYSIZE(key) ((key)->pubkey ? EVP_PKEY_get_size((key)->pubkey) : 0)
+
+/**
+ * Helper sign function for native keys
+ * Implemented using OpenSSL calls.
+ */
+int
+xkey_native_sign(XKEY_KEYDATA *key, unsigned char *sig, size_t *siglen,
+                 const unsigned char *tbs, size_t tbslen, XKEY_SIGALG sigalg);
+
 
 /* keymgmt provider */
 
@@ -388,6 +401,19 @@ ec_keymgmt_name(int id)
 {
     xkey_dmsg(D_LOW, "entry");
 
+    if (id == OSSL_OP_SIGNATURE)
+    {
+        return "ECDSA";
+    }
+    /* though we do not implement keyexch we could be queried for
+     * keyexch mechanism supported by EC keys
+     */
+    else if (id == OSSL_OP_KEYEXCH)
+    {
+        return "ECDH";
+    }
+
+    msg(D_LOW, "xkey ec_keymgmt_name called with op_id != SIGNATURE or KEYEXCH id=%d", id);
     return "EC";
 }
 
@@ -430,6 +456,473 @@ const OSSL_ALGORITHM keymgmts[] = {
     {NULL, NULL, NULL, NULL}
 };
 
+
+/* signature provider */
+
+/* signature provider callbacks we provide */
+static OSSL_FUNC_signature_newctx_fn signature_newctx;
+static OSSL_FUNC_signature_freectx_fn signature_freectx;
+static OSSL_FUNC_signature_sign_init_fn signature_sign_init;
+static OSSL_FUNC_signature_sign_fn signature_sign;
+static OSSL_FUNC_signature_digest_verify_init_fn signature_digest_verify_init;
+static OSSL_FUNC_signature_digest_verify_fn signature_digest_verify;
+static OSSL_FUNC_signature_digest_sign_init_fn signature_digest_sign_init;
+static OSSL_FUNC_signature_digest_sign_fn signature_digest_sign;
+static OSSL_FUNC_signature_set_ctx_params_fn signature_set_ctx_params;
+static OSSL_FUNC_signature_settable_ctx_params_fn signature_settable_ctx_params;
+static OSSL_FUNC_signature_get_ctx_params_fn signature_get_ctx_params;
+static OSSL_FUNC_signature_gettable_ctx_params_fn signature_gettable_ctx_params;
+
+typedef struct
+{
+    XKEY_PROVIDER_CTX *prov;
+    XKEY_KEYDATA *keydata;
+    XKEY_SIGALG sigalg;
+} XKEY_SIGNATURE_CTX;
+
+static const XKEY_SIGALG default_sigalg = { .mdname="MD5-SHA1", .saltlen="digest",
+                                            .padmode="pkcs1", .keytype = "RSA"};
+
+const struct {
+    int nid;
+    const char *name;
+} digest_names[] = {{NID_md5_sha1, "MD5-SHA1"}, {NID_sha1, "SHA1"},
+                    {NID_sha224, "SHA224",}, {NID_sha256, "SHA256"}, {NID_sha384, "SHA384"},
+                    {NID_sha512, "SHA512"}, {0, NULL}};
+
+/* Return a string literal for digest name - normalizes
+ * alternate names like SHA2-256 to SHA256 etc.
+ */
+static const char *
+xkey_mdname(const char *name)
+{
+    int i = 0;
+
+    int nid = EVP_MD_get_type(EVP_get_digestbyname(name));
+
+    while (digest_names[i].name && nid != digest_names[i].nid)
+    {
+        i++;
+    }
+    return digest_names[i].name ?  digest_names[i].name : "MD5-SHA1";
+}
+
+static void *
+signature_newctx(void *provctx, const char *propq)
+{
+    xkey_dmsg(D_LOW, "entry");
+
+    (void) propq; /* unused */
+
+    XKEY_SIGNATURE_CTX *sctx = calloc(sizeof(*sctx), 1);
+    if (!sctx)
+    {
+        msg(M_NONFATAL, "xkey_signature_newctx: out of memory");
+        return NULL;
+    }
+
+    sctx->prov = provctx;
+    sctx->sigalg = default_sigalg;
+
+    return sctx;
+}
+
+static void
+signature_freectx(void *ctx)
+{
+    xkey_dmsg(D_LOW, "entry");
+
+    XKEY_SIGNATURE_CTX *sctx = ctx;
+
+    keydata_free(sctx->keydata);
+
+    free(sctx);
+}
+
+static const OSSL_PARAM *
+signature_settable_ctx_params(void *ctx, void *provctx)
+{
+    xkey_dmsg(D_LOW, "entry");
+
+    static OSSL_PARAM settable[] = {
+        OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_PAD_MODE, NULL, 0),
+        OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_DIGEST, NULL, 0),
+        OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_PSS_SALTLEN, NULL, 0),
+        OSSL_PARAM_END
+    };
+
+    return settable;
+}
+
+static int
+signature_set_ctx_params(void *ctx, const OSSL_PARAM params[])
+{
+    xkey_dmsg(D_LOW, "entry");
+
+    XKEY_SIGNATURE_CTX *sctx = ctx;
+    const OSSL_PARAM *p;
+
+    if (params == NULL)
+    {
+        return 1;  /* not an error */
+    }
+    p = OSSL_PARAM_locate_const(params, OSSL_SIGNATURE_PARAM_PAD_MODE);
+    if (p && p->data_type == OSSL_PARAM_UTF8_STRING)
+    {
+        if (!strcmp(p->data, "pss"))
+        {
+            sctx->sigalg.padmode = "pss";
+        }
+        else if (!strcmp(p->data, "pkcs1"))
+        {
+            sctx->sigalg.padmode = "pkcs1";
+        }
+        else if (!strcmp(p->data, "none"))
+        {
+            sctx->sigalg.padmode = "none";
+        }
+        else
+        {
+            msg(M_WARN, "xkey signature_ctx: padmode <%s>, treating as <pkcs1>",
+                (char *)p->data);
+            sctx->sigalg.padmode = "none";
+        }
+        xkey_dmsg(D_LOW, "setting padmode as %s", sctx->sigalg.padmode);
+    }
+    else if (p && p->data_type == OSSL_PARAM_INTEGER)
+    {
+        int padmode;
+        if (OSSL_PARAM_get_int(p, &padmode))
+        {
+            if (padmode == RSA_PKCS1_PSS_PADDING)
+            {
+                sctx->sigalg.padmode = "pss";
+            }
+            else if (padmode == RSA_PKCS1_PADDING)
+            {
+                sctx->sigalg.padmode = "pkcs1";
+            }
+            else
+            {
+                sctx->sigalg.padmode = "none";
+            }
+        }
+        xkey_dmsg(D_LOW, "setting padmode as <%s>", sctx->sigalg.padmode);
+    }
+    else if (p)
+    {
+        msg(M_WARN, "xkey_signature_params: unknown padmode ignored");
+    }
+
+    p = OSSL_PARAM_locate_const(params, OSSL_SIGNATURE_PARAM_DIGEST);
+    if (p  &&  p->data_type == OSSL_PARAM_UTF8_STRING)
+    {
+        sctx->sigalg.mdname = xkey_mdname(p->data);
+        xkey_dmsg(D_LOW, "setting hashalg as %s", sctx->sigalg.mdname);
+    }
+    else if (p)
+    {
+        msg(M_WARN, "xkey_signature_params: unknown digest type ignored");
+    }
+
+    p = OSSL_PARAM_locate_const(params, OSSL_SIGNATURE_PARAM_PSS_SALTLEN);
+    if (p && p->data_type == OSSL_PARAM_UTF8_STRING)
+    {
+        if (!strcmp((char *)p->data, "digest"))
+        {
+            sctx->sigalg.saltlen = "digest";
+        }
+        else if (!strcmp(p->data, "max"))
+        {
+            sctx->sigalg.saltlen = "max";
+        }
+        else if (!strcmp(p->data, "auto"))
+        {
+            sctx->sigalg.saltlen = "auto";
+        }
+        else
+        {
+            msg(M_WARN, "xkey_signature_params: unknown saltlen <%s>",
+                (char *)p->data);
+            sctx->sigalg.saltlen = "digest"; /* most common */
+        }
+        xkey_dmsg(D_LOW, "setting saltlen to %s", sctx->sigalg.saltlen);
+    }
+    else if (p)
+    {
+        msg(M_WARN, "xkey_signature_params: unknown saltlen ignored");
+    }
+
+    return 1;
+}
+
+static const OSSL_PARAM *
+signature_gettable_ctx_params(void *ctx, void *provctx)
+{
+    xkey_dmsg(D_LOW,"entry");
+
+    static OSSL_PARAM gettable[] = { OSSL_PARAM_END }; /* Empty list */
+
+    return gettable;
+}
+
+static int
+signature_get_ctx_params(void *ctx, OSSL_PARAM params[])
+{
+    xkey_dmsg(D_LOW, "not implemented");
+    return 0;
+}
+
+static int
+signature_sign_init(void *ctx, void *provkey, const OSSL_PARAM params[])
+{
+    xkey_dmsg(D_LOW, "entry");
+
+    XKEY_SIGNATURE_CTX *sctx = ctx;
+
+    if (sctx->keydata)
+    {
+        keydata_free(sctx->keydata);
+    }
+    sctx->keydata = provkey;
+    sctx->keydata->refcount++; /* we are keeping a copy */
+    sctx->sigalg.keytype = KEYTYPE(sctx->keydata) == EVP_PKEY_RSA ? "RSA" : "EC";
+
+    signature_set_ctx_params(sctx, params);
+
+    return 1;
+}
+
+/* Sign digest or message using sign function */
+static int
+xkey_sign_dispatch(XKEY_SIGNATURE_CTX *sctx, unsigned char *sig, size_t *siglen,
+                   const unsigned char *tbs, size_t tbslen)
+{
+    XKEY_EXTERNAL_SIGN_fn *sign = sctx->keydata->sign;
+    int ret = 0;
+
+    if (sctx->keydata->origin == OPENSSL_NATIVE)
+    {
+        ret = xkey_native_sign(sctx->keydata, sig, siglen, tbs, tbslen, sctx->sigalg);
+    }
+    else if (sign)
+    {
+        ret = sign(sctx->keydata->handle, sig, siglen, tbs, tbslen, sctx->sigalg);
+        xkey_dmsg(D_LOW, "xkey_provider: external sign op returned ret = %d siglen = %d", ret, (int) *siglen);
+    }
+    else
+    {
+        msg(M_NONFATAL, "xkey_provider: Internal error: No sign callback for external key.");
+    }
+
+    return ret;
+}
+
+static int
+signature_sign(void *ctx, unsigned char *sig, size_t *siglen, size_t sigsize,
+               const unsigned char *tbs, size_t tbslen)
+{
+    xkey_dmsg(D_LOW, "entry with siglen = %zu\n", *siglen);
+
+    XKEY_SIGNATURE_CTX *sctx = ctx;
+    ASSERT(sctx);
+    ASSERT(sctx->keydata);
+
+    if (!sig)
+    {
+        *siglen = KEYSIZE(sctx->keydata);
+        return 1;
+    }
+
+    sctx->sigalg.op = "Sign";
+    return xkey_sign_dispatch(sctx, sig, siglen, tbs, tbslen);
+}
+
+static int
+signature_digest_verify_init(void *ctx, const char *mdname, void *provkey,
+                             const OSSL_PARAM params[])
+{
+    xkey_dmsg(D_LOW, "mdname <%s>", mdname);
+
+    msg(M_WARN, "xkey_provider: DigestVerifyInit is not implemented");
+    return 0;
+}
+
+static int
+signature_digest_verify(void *ctx, const unsigned char *sig, size_t siglen,
+                        const unsigned char *tbs, size_t tbslen)
+{
+    xkey_dmsg(D_LOW, "entry");
+
+    msg(M_WARN, "xkey_provider: DigestVerify is not implemented");
+    return 0;
+}
+
+static int
+signature_digest_sign_init(void *ctx, const char *mdname,
+                           void *provkey, const OSSL_PARAM params[])
+{
+    xkey_dmsg(D_LOW, "mdname = <%s>", mdname);
+
+    XKEY_SIGNATURE_CTX *sctx = ctx;
+
+    ASSERT(sctx);
+    ASSERT(provkey);
+    ASSERT(sctx->prov);
+
+    if (sctx->keydata)
+    {
+        keydata_free(sctx->keydata);
+    }
+    sctx->keydata = provkey; /* used by digest_sign */
+    sctx->keydata->refcount++;
+    sctx->sigalg.keytype = KEYTYPE(sctx->keydata) == EVP_PKEY_RSA ? "RSA" : "EC";
+
+    signature_set_ctx_params(ctx, params);
+    if (mdname)
+    {
+        sctx->sigalg.mdname = xkey_mdname(mdname); /* get a string literal pointer */
+    }
+    else
+    {
+        msg(M_WARN, "xkey digest_sign_init: mdname is NULL.");
+    }
+    return 1;
+}
+
+static int
+signature_digest_sign(void *ctx, unsigned char *sig, size_t *siglen,
+                      size_t sigsize, const unsigned char *tbs, size_t tbslen)
+{
+    xkey_dmsg(D_LOW, "entry");
+
+    XKEY_SIGNATURE_CTX *sctx = ctx;
+
+    ASSERT(sctx);
+    ASSERT(sctx->keydata);
+
+    if (!sig) /* set siglen and return */
+    {
+        *siglen = KEYSIZE(sctx->keydata);
+        return 1;
+    }
+
+    if (sctx->keydata->origin != OPENSSL_NATIVE)
+    {
+        /* pass the message itself to the backend */
+        sctx->sigalg.op = "DigestSign";
+        return xkey_sign_dispatch(ctx, sig, siglen, tbs, tbslen);
+    }
+
+    /* create digest and pass on to signature_sign() */
+
+    const char *mdname = sctx->sigalg.mdname;
+    EVP_MD *md = EVP_MD_fetch(sctx->prov->libctx, mdname, NULL);
+    if (!md)
+    {
+        msg(M_WARN, "WARN: xkey digest_sign_init: MD_fetch failed for <%s>", mdname);
+        return 0;
+    }
+
+    /* construct digest using OpenSSL */
+    unsigned char buf[EVP_MAX_MD_SIZE];
+    unsigned int sz;
+    if (EVP_Digest(tbs, tbslen, buf, &sz, md, NULL) != 1)
+    {
+        msg(M_WARN, "WARN: xkey digest_sign: EVP_Digest failed");
+        EVP_MD_free(md);
+        return 0;
+    }
+    EVP_MD_free(md);
+
+    return signature_sign(ctx, sig, siglen, sigsize, buf, sz);
+}
+
+/* Sign digest using native sign function -- will only work for native keys
+ */
+int
+xkey_native_sign(XKEY_KEYDATA *key, unsigned char *sig, size_t *siglen,
+                 const unsigned char *tbs, size_t tbslen, XKEY_SIGALG sigalg)
+{
+    xkey_dmsg(D_LOW, "entry");
+
+    ASSERT(key);
+
+    EVP_PKEY *pkey = key->handle;
+    int ret = 0;
+
+    ASSERT(sig);
+
+    if (!pkey)
+    {
+        msg(M_NONFATAL, "Error: xkey provider: signature request with empty private key");
+        return 0;
+    }
+
+    const char *saltlen = sigalg.saltlen;
+    const char *mdname = sigalg.mdname;
+    const char *padmode = sigalg.padmode;
+
+    xkey_dmsg(D_LOW, "digest=<%s>, padmode=<%s>, saltlen=<%s>", mdname, padmode, saltlen);
+
+    int i = 0;
+    OSSL_PARAM params[6];
+    if (EVP_PKEY_get_id(pkey) == EVP_PKEY_RSA)
+    {
+        params[i++] = OSSL_PARAM_construct_utf8_string(OSSL_SIGNATURE_PARAM_DIGEST, (char *)mdname, 0);
+        params[i++] = OSSL_PARAM_construct_utf8_string(OSSL_SIGNATURE_PARAM_PAD_MODE, (char *)padmode, 0);
+        if (!strcmp(sigalg.padmode, "pss"))
+        {
+            params[i++] = OSSL_PARAM_construct_utf8_string(OSSL_SIGNATURE_PARAM_PSS_SALTLEN, (char *) saltlen, 0);
+            /* same digest for mgf1 */
+            params[i++] = OSSL_PARAM_construct_utf8_string(OSSL_SIGNATURE_PARAM_MGF1_DIGEST, (char *) mdname, 0);
+        }
+    }
+    params[i++] = OSSL_PARAM_construct_end();
+
+    EVP_PKEY_CTX *ectx = EVP_PKEY_CTX_new_from_pkey(key->prov->libctx, pkey, NULL);
+
+    if (!ectx)
+    {
+        msg(M_WARN, "WARN: xkey test_sign: call to EVP_PKEY_CTX_new...failed");
+        return 0;
+    }
+
+    if (EVP_PKEY_sign_init_ex(ectx, NULL) != 1)
+    {
+        msg(M_WARN, "WARN: xkey test_sign: call to EVP_PKEY_sign_init failed");
+        return 0;
+    }
+    EVP_PKEY_CTX_set_params(ectx, params);
+
+    ret = EVP_PKEY_sign(ectx, sig, siglen, tbs, tbslen);
+    EVP_PKEY_CTX_free(ectx);
+
+    return ret;
+}
+
+static const OSSL_DISPATCH signature_functions[] = {
+    {OSSL_FUNC_SIGNATURE_NEWCTX, (void (*)(void)) signature_newctx},
+    {OSSL_FUNC_SIGNATURE_FREECTX, (void (*)(void)) signature_freectx},
+    {OSSL_FUNC_SIGNATURE_SIGN_INIT, (void (*)(void)) signature_sign_init},
+    {OSSL_FUNC_SIGNATURE_SIGN, (void (*)(void)) signature_sign},
+    {OSSL_FUNC_SIGNATURE_DIGEST_VERIFY_INIT, (void (*)(void)) signature_digest_verify_init},
+    {OSSL_FUNC_SIGNATURE_DIGEST_VERIFY, (void (*)(void)) signature_digest_verify},
+    {OSSL_FUNC_SIGNATURE_DIGEST_SIGN_INIT, (void (*)(void)) signature_digest_sign_init},
+    {OSSL_FUNC_SIGNATURE_DIGEST_SIGN, (void (*)(void)) signature_digest_sign},
+    {OSSL_FUNC_SIGNATURE_SET_CTX_PARAMS, (void (*)(void)) signature_set_ctx_params},
+    {OSSL_FUNC_SIGNATURE_SETTABLE_CTX_PARAMS, (void (*)(void)) signature_settable_ctx_params},
+    {OSSL_FUNC_SIGNATURE_GET_CTX_PARAMS, (void (*)(void)) signature_get_ctx_params},
+    {OSSL_FUNC_SIGNATURE_GETTABLE_CTX_PARAMS, (void (*)(void)) signature_gettable_ctx_params},
+    {0, NULL }
+};
+
+const OSSL_ALGORITHM signatures[] = {
+    {"RSA:rsaEncryption", props, signature_functions, "OpenVPN xkey RSA Signature"},
+    {"ECDSA", props, signature_functions, "OpenVPN xkey ECDSA Signature"},
+    {NULL, NULL, NULL, NULL}
+};
+
 /* main provider interface */
 
 /* provider callbacks we implement */
@@ -448,7 +941,7 @@ query_operation(void *provctx, int op, int *no_store)
     switch (op)
     {
         case OSSL_OP_SIGNATURE:
-            return NULL;
+            return signatures;
 
         case OSSL_OP_KEYMGMT:
             return keymgmts;

--- a/src/openvpn/xkey_provider.c
+++ b/src/openvpn/xkey_provider.c
@@ -28,12 +28,12 @@
 #include "config-msvc.h"
 #endif
 
-#ifdef HAVE_XKEY_PROVIDER
-
 #include "syshead.h"
 #include "error.h"
 #include "buffer.h"
 #include "xkey_common.h"
+
+#ifdef HAVE_XKEY_PROVIDER
 
 #include <openssl/provider.h>
 #include <openssl/params.h>
@@ -52,8 +52,7 @@ static const char *provname = "OpenVPN External Key Provider";
 
 typedef struct
 {
-    OSSL_LIB_CTX *libctx;  /*  a child libctx for our own use */
-    OSSL_PROVIDER *deflt;  /* default provider that we load for delegating some ops */
+    OSSL_LIB_CTX *libctx;  /**< a child libctx for our own use */
 } XKEY_PROVIDER_CTX;
 
 /* helper to print debug messages */
@@ -1118,15 +1117,11 @@ teardown(void *provctx)
     xkey_dmsg(D_LOW, "entry");
 
     XKEY_PROVIDER_CTX *prov = provctx;
-    if (prov && prov->deflt)
-    {
-        OSSL_PROVIDER_unload(prov->deflt);
-    }
     if (prov && prov->libctx)
     {
         OSSL_LIB_CTX_free(prov->libctx);
     }
-    free(prov);
+    OPENSSL_free(prov);
 }
 
 static const OSSL_DISPATCH dispatch_table[] = {
@@ -1145,7 +1140,7 @@ xkey_provider_init(const OSSL_CORE_HANDLE *handle, const OSSL_DISPATCH *in,
 
     xkey_dmsg(D_LOW, "entry");
 
-    prov = calloc(sizeof(*prov), 1);
+    prov = OPENSSL_zalloc(sizeof(*prov));
     if (!prov)
     {
         msg(M_NONFATAL, "xkey_provider_init: out of memory");

--- a/src/openvpn/xkey_provider.c
+++ b/src/openvpn/xkey_provider.c
@@ -1,0 +1,174 @@
+/*
+ *  OpenVPN -- An application to securely tunnel IP networks
+ *             over a single TCP/UDP port, with support for SSL/TLS-based
+ *             session authentication and key exchange,
+ *             packet encryption, packet authentication, and
+ *             packet compression.
+ *
+ *  Copyright (C) 2021 Selva Nair <selva.nair@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by the
+ *  Free Software Foundation, either version 2 of the License,
+ *  or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#elif defined(_MSC_VER)
+#include "config-msvc.h"
+#endif
+
+#ifdef HAVE_XKEY_PROVIDER
+
+#include "syshead.h"
+#include "error.h"
+#include "buffer.h"
+#include "xkey_common.h"
+
+#include <openssl/provider.h>
+#include <openssl/params.h>
+#include <openssl/core_dispatch.h>
+#include <openssl/core_object.h>
+#include <openssl/core_names.h>
+#include <openssl/store.h>
+#include <openssl/evp.h>
+#include <openssl/err.h>
+
+/* A descriptive name */
+static const char *provname = "OpenVPN External Key Provider";
+
+typedef struct
+{
+    OSSL_LIB_CTX *libctx;  /*  a child libctx for our own use */
+    OSSL_PROVIDER *deflt;  /* default provider that we load for delegating some ops */
+} XKEY_PROVIDER_CTX;
+
+/* helper to print debug messages */
+#define xkey_dmsg(f, ...) \
+        do {                                                        \
+              dmsg(f|M_NOLF, "xkey_provider: In %s: ", __func__);    \
+              dmsg(f|M_NOPREFIX, __VA_ARGS__);                      \
+           } while(0)
+
+/* main provider interface */
+
+/* provider callbacks we implement */
+static OSSL_FUNC_provider_query_operation_fn query_operation;
+static OSSL_FUNC_provider_gettable_params_fn gettable_params;
+static OSSL_FUNC_provider_get_params_fn get_params;
+static OSSL_FUNC_provider_teardown_fn teardown;
+
+static const OSSL_ALGORITHM *
+query_operation(void *provctx, int op, int *no_store)
+{
+    xkey_dmsg(D_LOW, "op = %d", op);
+
+    *no_store = 0;
+
+    switch (op)
+    {
+        case OSSL_OP_SIGNATURE:
+            return NULL;
+
+        case OSSL_OP_KEYMGMT:
+            return NULL;
+
+        default:
+            xkey_dmsg(D_LOW, "op not supported");
+            break;
+    }
+    return NULL;
+}
+
+static const OSSL_PARAM *
+gettable_params(void *provctx)
+{
+    xkey_dmsg(D_LOW, "entry");
+
+    static const OSSL_PARAM param_types[] = {
+        OSSL_PARAM_DEFN(OSSL_PROV_PARAM_NAME, OSSL_PARAM_UTF8_PTR, NULL, 0),
+        OSSL_PARAM_END
+    };
+
+    return param_types;
+}
+static int
+get_params(void *provctx, OSSL_PARAM params[])
+{
+    OSSL_PARAM *p;
+
+    xkey_dmsg(D_LOW, "entry");
+
+    p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_NAME);
+    if (p)
+    {
+        return (OSSL_PARAM_set_utf8_ptr(p, provname) != 0);
+    }
+
+    return 0;
+}
+
+static void
+teardown(void *provctx)
+{
+    xkey_dmsg(D_LOW, "entry");
+
+    XKEY_PROVIDER_CTX *prov = provctx;
+    if (prov && prov->deflt)
+    {
+        OSSL_PROVIDER_unload(prov->deflt);
+    }
+    if (prov && prov->libctx)
+    {
+        OSSL_LIB_CTX_free(prov->libctx);
+    }
+    free(prov);
+}
+
+static const OSSL_DISPATCH dispatch_table[] = {
+    {OSSL_FUNC_PROVIDER_GETTABLE_PARAMS, (void (*)(void)) gettable_params},
+    {OSSL_FUNC_PROVIDER_GET_PARAMS, (void (*)(void)) get_params},
+    {OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void)) query_operation},
+    {OSSL_FUNC_PROVIDER_TEARDOWN, (void (*)(void)) teardown},
+    {0, NULL}
+};
+
+int
+xkey_provider_init(const OSSL_CORE_HANDLE *handle, const OSSL_DISPATCH *in,
+                   const OSSL_DISPATCH **out, void **provctx)
+{
+    XKEY_PROVIDER_CTX *prov;
+
+    xkey_dmsg(D_LOW, "entry");
+
+    prov = calloc(sizeof(*prov), 1);
+    if (!prov)
+    {
+        msg(M_NONFATAL, "xkey_provider_init: out of memory");
+        return 0;
+    }
+
+    /* Make a child libctx for our use and set default prop query
+     * on it to ensure calls we delegate won't loop back to us.
+     */
+    prov->libctx = OSSL_LIB_CTX_new_child(handle, in);
+
+    EVP_set_default_properties(prov->libctx, "provider!=ovpn.xkey");
+
+    *out = dispatch_table;
+    *provctx = prov;
+
+    return 1;
+}
+
+#endif /* HAVE_XKEY_PROVIDER */

--- a/tests/unit_tests/openvpn/Makefile.am
+++ b/tests/unit_tests/openvpn/Makefile.am
@@ -11,9 +11,7 @@ if HAVE_LD_WRAP_SUPPORT
 test_binaries += tls_crypt_testdriver
 endif
 
-if HAVE_XKEY_PROVIDER
 test_binaries += provider_testdriver
-endif
 
 TESTS = $(test_binaries)
 check_PROGRAMS = $(test_binaries)
@@ -99,7 +97,6 @@ networking_testdriver_SOURCES = test_networking.c mock_msg.c \
 	$(openvpn_srcdir)/platform.c
 endif
 
-if HAVE_XKEY_PROVIDER
 provider_testdriver_CFLAGS  = @TEST_CFLAGS@ \
 	-I$(openvpn_includedir) -I$(compat_srcdir) -I$(openvpn_srcdir) \
 	$(OPTIONAL_CRYPTO_CFLAGS)
@@ -113,7 +110,6 @@ provider_testdriver_SOURCES = test_provider.c mock_msg.c \
 	$(openvpn_srcdir)/base64.c \
 	mock_get_random.c \
 	$(openvpn_srcdir)/platform.c
-endif
 
 auth_token_testdriver_CFLAGS  = @TEST_CFLAGS@ \
 	-I$(openvpn_includedir) -I$(compat_srcdir) -I$(openvpn_srcdir) \

--- a/tests/unit_tests/openvpn/Makefile.am
+++ b/tests/unit_tests/openvpn/Makefile.am
@@ -11,6 +11,10 @@ if HAVE_LD_WRAP_SUPPORT
 test_binaries += tls_crypt_testdriver
 endif
 
+if HAVE_XKEY_PROVIDER
+test_binaries += provider_testdriver
+endif
+
 TESTS = $(test_binaries)
 check_PROGRAMS = $(test_binaries)
 
@@ -92,6 +96,22 @@ networking_testdriver_SOURCES = test_networking.c mock_msg.c \
 	$(openvpn_srcdir)/crypto_openssl.c \
 	$(openvpn_srcdir)/otime.c \
 	$(openvpn_srcdir)/packet_id.c \
+	$(openvpn_srcdir)/platform.c
+endif
+
+if HAVE_XKEY_PROVIDER
+provider_testdriver_CFLAGS  = @TEST_CFLAGS@ \
+	-I$(openvpn_includedir) -I$(compat_srcdir) -I$(openvpn_srcdir) \
+	$(OPTIONAL_CRYPTO_CFLAGS)
+provider_testdriver_LDFLAGS = @TEST_LDFLAGS@ \
+	$(OPTIONAL_CRYPTO_LIBS)
+
+provider_testdriver_SOURCES = test_provider.c mock_msg.c \
+	$(openvpn_srcdir)/xkey_helper.c \
+	$(openvpn_srcdir)/xkey_provider.c \
+	$(openvpn_srcdir)/buffer.c \
+	$(openvpn_srcdir)/base64.c \
+	mock_get_random.c \
 	$(openvpn_srcdir)/platform.c
 endif
 


### PR DESCRIPTION
Hooking into callbacks in RSA_METHOD and EVP_PKEY_METHOD
structures is deprecated in OpenSSL 3.0. For signing with external
keys that are not exportable (tokens, key stores, etc.) requires a custom
provider interface so that key operations can be delegated to it.

A single provider is enough for handling all external key options we support:
 --management-external-key
 --cryptoapicert
 --pkcs11-id

The series of patches in this PR implements such a provider.