### PR TITLE
doc/man (vpn-network-options): fix foreign_option_{n} typo

### DIFF
--- a/doc/man-sections/vpn-network-options.rst
+++ b/doc/man-sections/vpn-network-options.rst
@@ -107,7 +107,7 @@ routing.
   ``OpenVPN for Android`` client also handles them internally.
 
   On all other platforms these options are only saved in the client's
-  environment under the name :code:`foreign_options_{n}` before the
+  environment under the name :code:`foreign_option_{n}` before the
   ``--up`` script is called. A plugin or an ``--up`` script must be used to
   pick up and interpret these as required. Many Linux distributions include
   such scripts and some third-party user interfaces such as tunnelblick also


### PR DESCRIPTION
In 2da29362 (Improve the documentation for --dhcp-option, 2020-08-16),
`foreign_option_{n}` became plural between the first and second versions
of the patch.  Correct it.

Signed-off-by: Todd Zullinger <tmz@pobox.com>

# Thank you for your contribution

You are welcome to open PR, but they are used for discussion only. All
patches must eventually go to the openvpn-devel mailing list for review:

* https://lists.sourceforge.net/lists/listinfo/openvpn-devel

Please send your patch using [git-send-email](https://git-scm.com/docs/git-send-email). For example to send your latest commit to the list:

    $ git send-email --to=openvpn-devel@lists.sourceforge.net HEAD~1

For details, see these Wiki articles:

* https://community.openvpn.net/openvpn/wiki/DeveloperDocumentation
* https://community.openvpn.net/openvpn/wiki/Contributing
