### PR TITLE
Update IRC information in CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -19,10 +19,10 @@ git-format-patch or sent using git-send-email. Try to split large patches into
 small, atomic pieces to make reviews easier.
 
 If you want quick feedback on a patch before sending it to openvpn-devel mailing
-list, you can visit the #openvpn-devel channel on irc.freenode.net. Note that
-you need to be logged in to Freenode to join the channel:
+list, you can visit the #openvpn-devel channel on irc.libera.chat. Note that
+you need to be logged in to Libera to join the channel:
 
-- http://freenode.net/faq.shtml#nicksetup
+- https://libera.chat/guides/registration
 
 More detailed contribution instructions are available here:
 


### PR DESCRIPTION
The developer IRC channel is now on libera.chat.  Update
CONTRIBUTING.rst to match the wiki.

Signed-off-by: Todd Zullinger <tmz@pobox.com>

# Thank you for your contribution

You are welcome to open PR, but they are used for discussion only. All
patches must eventually go to the openvpn-devel mailing list for review:

* https://lists.sourceforge.net/lists/listinfo/openvpn-devel

Please send your patch using [git-send-email](https://git-scm.com/docs/git-send-email). For example to send your latest commit to the list:

    $ git send-email --to=openvpn-devel@lists.sourceforge.net HEAD~1

For details, see these Wiki articles:

* https://community.openvpn.net/openvpn/wiki/DeveloperDocumentation
* https://community.openvpn.net/openvpn/wiki/Contributing
