### PR TITLE
support configure multiple certificates on the server side

### DIFF
--- a/src/openvpn/options.c
+++ b/src/openvpn/options.c
@@ -1568,7 +1568,6 @@ show_pull_filter_list(const struct pull_filter_list *l)
 void
 show_settings(const struct options *o)
 {
-    int i;
 #ifndef ENABLE_SMALL
     msg(D_SHOW_PARMS, "Current Parameter Settings:");
 
@@ -1746,7 +1745,7 @@ show_settings(const struct options *o)
     }
     else
 #endif
-    for( i = 0; i < OPENVPN_MAX_CERT_KEY_PAIR; i++ )
+    for( int i = 0; i < OPENVPN_MAX_CERT_KEY_PAIR; i++ )
       SHOW_PARM(cert_file[i], \
                   o->cert_file_inline[i] ? "[INLINE]" : \
                   (o->cert_file[i] ? o->cert_file[i] : "[UNDEF]"), \
@@ -1760,7 +1759,7 @@ show_settings(const struct options *o)
     }
     else
 #endif
-    for( i = 0; i < OPENVPN_MAX_CERT_KEY_PAIR; i++ )
+    for( int i = 0; i < OPENVPN_MAX_CERT_KEY_PAIR; i++ )
       SHOW_PARM(priv_key_file[i], \
                   o->priv_key_file_inline[i] ? "[INLINE]" : \
                   (o->priv_key_file[i] ? o->priv_key_file[i] : "[UNDEF]"), \

--- a/src/openvpn/options.h
+++ b/src/openvpn/options.h
@@ -221,6 +221,8 @@ struct verify_hash_list
     struct verify_hash_list *next;
 };
 
+#define OPENVPN_MAX_CERT_KEY_PAIR 10
+
 /* Command line options */
 struct options
 {
@@ -550,12 +552,12 @@ struct options
     const char *ca_path;
     const char *dh_file;
     bool dh_file_inline;
-    const char *cert_file;
-    bool cert_file_inline;
+    const char *cert_file[OPENVPN_MAX_CERT_KEY_PAIR];
+    bool cert_file_inline[OPENVPN_MAX_CERT_KEY_PAIR];
     const char *extra_certs_file;
     bool extra_certs_file_inline;
-    const char *priv_key_file;
-    bool priv_key_file_inline;
+    const char *priv_key_file[OPENVPN_MAX_CERT_KEY_PAIR];
+    bool priv_key_file_inline[OPENVPN_MAX_CERT_KEY_PAIR];
     const char *pkcs12_file;
     bool pkcs12_file_inline;
     const char *cipher_list;


### PR DESCRIPTION
support configure multiple certificates on the server side, such as ECC and RSA.

openvpn server configure both ECC and RSA certificates, then openvpn clients can choose different certificates according to cipher suite.

server config:
ca /opt/local/certs/CA.crt
cert /opt/local/certs/RSA_S.crt
key /opt/local/certs/RSA_S.key
cert /opt/local/certs/ECC_S.crt
key /opt/local/certs/ECC_S.key

client1 config:
ca /opt/local/certs/CA.crt
cert /opt/local/certs/RSA_C.crt
key /opt/local/certs/RSA_C.key
tls-cipher TLS-ECDHE-RSA-WITH-AES-256-GCM-SHA384
tls-version-max 1.2

client2 config:
ca /opt/local/certs/CA.crt
cert /opt/local/certs/ECC_C.crt
key /opt/local/certs/ECC_C.key
tls-cipher TLS-ECDHE-ECDSA-WITH-AES-256-GCM-SHA384
tls-version-max 1.2
