### PR TITLE
To be able to run OpenVPN client in Docker container

### DIFF
--- a/contrib/pull-resolv-conf/client.down
+++ b/contrib/pull-resolv-conf/client.down
@@ -44,7 +44,7 @@ if type resolvconf >/dev/null 2>&1; then
   resolvconf -d "${dev}" -f
 elif [ -e /etc/resolv.conf.ovpnsave ] ; then
   # cp + rm rather than mv in case it's a symlink
-  cp /etc/resolv.conf.ovpnsave /etc/resolv.conf
+  cat /etc/resolv.conf.ovpnsave > /etc/resolv.conf
   rm -f /etc/resolv.conf.ovpnsave
 fi
 


### PR DESCRIPTION
The file `/etc/resolv.conf` is not a regular one in Docker container, it is a bind-mount within container.
It cause `cp: can't create '/etc/resolv.conf': File exists` error and as a result `resolv.conf.ovpnsave` is not copied back as it is intended.
But rewriting the file instead of moving or renaming is possible.