### PR TITLE
fix typo in help text: --ignore-unknown-option

### DIFF
--- a/src/openvpn/options.c
+++ b/src/openvpn/options.c
@@ -248,7 +248,7 @@ static const char usage_message[] =
     "--setenv name value : Set a custom environmental variable to pass to script.\n"
     "--setenv FORWARD_COMPATIBLE 1 : Relax config file syntax checking to allow\n"
     "                  directives for future OpenVPN versions to be ignored.\n"
-    "--ignore-unkown-option opt1 opt2 ...: Relax config file syntax. Allow\n"
+    "--ignore-unknown-option opt1 opt2 ...: Relax config file syntax. Allow\n"
     "                  these options to be ignored when unknown\n"
     "--script-security level: Where level can be:\n"
     "                  0 -- strictly no calling of external programs\n"


### PR DESCRIPTION
I failed to send it per git mail or manually. And the change is not big enough and won't require any feedback.

Feel free to recommit it, or do whatever with it.
