### PR TITLE
Bug-fix: Wrong CR_RESPONSE KID in management api

### DIFF
--- a/src/openvpn/push.c
+++ b/src/openvpn/push.c
@@ -265,7 +265,7 @@ receive_cr_response(struct context *c, const struct buffer *buffer)
     struct tls_session *session = &c->c2.tls_multi->session[TM_ACTIVE];
     struct man_def_auth_context *mda = session->opt->mda_context;
     struct env_set *es = session->opt->es;
-    int key_id = get_primary_key(c->c2.tls_multi)->key_id;
+    int key_id = get_primary_key(c->c2.tls_multi)->mda_key_id;
 
     management_notify_client_cr_response(key_id, mda, es, m);
 #endif


### PR DESCRIPTION
The `KID` passed to the management interface when processing `CR_RESPONSE` was previously wrong, which caused some problem when handling the challenge-response (crtext) protocol. Modified `push.c` to pass the `mda_key_id` instead of the `key_id` to the management interface.