### PR TITLE
Implement server_poll_timeout for socks instead of hard-coded 5 sec

### DIFF
--- a/src/openvpn/socket.c
+++ b/src/openvpn/socket.c
@@ -2075,6 +2075,7 @@ phase2_tcp_client(struct link_socket *sock, struct signal_info *sig_info)
                                            sock->sd,
                                            sock->proxy_dest_host,
                                            sock->proxy_dest_port,
+                                           sock->server_poll_timeout,
                                            sig_info);
         }
         if (proxy_retry)
@@ -2104,6 +2105,7 @@ phase2_socks_client(struct link_socket *sock, struct signal_info *sig_info)
                                    sock->ctrl_sd,
                                    sock->sd,
                                    &sock->socks_relay.dest,
+                                   sock->server_poll_timeout,
                                    sig_info);
 
     if (sig_info->signal_received)

--- a/src/openvpn/socks.h
+++ b/src/openvpn/socks.h
@@ -52,12 +52,14 @@ void establish_socks_proxy_passthru(struct socks_proxy_info *p,
                                     socket_descriptor_t sd,  /* already open to proxy */
                                     const char *host,        /* openvpn server remote */
                                     const char *servname,          /* openvpn server port */
+                                    struct event_timeout *server_poll_timeout,
                                     struct signal_info *sig_info);
 
 void establish_socks_proxy_udpassoc(struct socks_proxy_info *p,
                                     socket_descriptor_t ctrl_sd,  /* already open to proxy */
                                     socket_descriptor_t udp_sd,
                                     struct openvpn_sockaddr *relay_addr,
+                                    struct event_timeout *server_poll_timeout,
                                     struct signal_info *sig_info);
 
 void socks_process_incoming_udp(struct buffer *buf,


### PR DESCRIPTION
People have been struggling to run openvpn over slow proxies. 
There was a bug [#328](https://community.openvpn.net/openvpn/ticket/328) submitted 10 years ago. 
To fix this, the server-poll-timeout config value was introduced, but has only been implemented for http proxies. 
For socks the timeouts are still hard-coded to 5 sec.
That's why people are still having problems, see [issue #267](https://github.com/OpenVPN/openvpn/issues/267) 

I submitted a [patch](https://www.mail-archive.com/openvpn-devel@lists.sourceforge.net/msg26962.html) to the mailing list, but since this was my first time using a mailing list over git, I failed to provide details in the mail.

With this patch, establishing a socks connection uses the timeout set by server-poll-timeout (default: 120s).
I used the same logic like it was implemented for http proxies, which includes the socks handshake for the timeout.

So here's a PR with more details, in hope that it gets reviewed and implemented soon.