### PR TITLE
fix(ssl): init peer_id when init tls_multi

### DIFF
--- a/src/openvpn/ssl.c
+++ b/src/openvpn/ssl.c
@@ -64,6 +64,7 @@
 #include "dco.h"
 
 #include "memdbg.h"
+#include "openvpn.h"
 
 #ifdef MEASURE_TLS_HANDSHAKE_STATS
 
@@ -1312,6 +1313,7 @@ tls_multi_init(struct tls_options *tls_options)
     /* get command line derived options */
     ret->opt = *tls_options;
     ret->dco_peer_id = -1;
+    ret->peer_id = MAX_PEER_ID;
 
     return ret;
 }


### PR DESCRIPTION
When openvpn run in UDP server mode, if ssl connections reach the max clients, the next connection will fail in `multi_create_instance` and the half connection will be close in `multi_close_instance`, which may lead array `m->instances[0]`  covered unexpectedly and make the first connection  interrupt, this patch fix this problem by init `peer_id` with `MAX_PEER_ID` in `tils_multi_init`.
