### PR TITLE
doc: Correct typos in multiple documentation files

### DIFF
--- a/doc/man-sections/client-options.rst
+++ b/doc/man-sections/client-options.rst
@@ -51,9 +51,9 @@ configuration.
   react according to ``--auth-retry``
 
 --auth-token-user base64username
-  Companion option to ``--auth-token``. This options allows to override
+  Companion option to ``--auth-token``. This options allows one to override
   the username used by the client when reauthenticating with the ``auth-token``.
-  It also allows to use ``--auth-token`` in setups that normally do not use
+  It also allows one to use ``--auth-token`` in setups that normally do not use
   username and password.
 
   The username has to be base64 encoded.

--- a/doc/man-sections/generic-options.rst
+++ b/doc/man-sections/generic-options.rst
@@ -483,7 +483,7 @@ which mode OpenVPN is configured as.
 
   * :code:`OPENVPN_PLUGIN_AUTH_USER_PASS_VERIFY` plug-in hooks returns
     success/failure via :code:`auth_control_file` when using deferred auth
-    method and pending authentification via :code:`pending_auth_file`.
+    method and pending authentication via :code:`pending_auth_file`.
 
 --use-prediction-resistance
   Enable prediction resistance on mbed TLS's RNG.

--- a/doc/man-sections/server-options.rst
+++ b/doc/man-sections/server-options.rst
@@ -739,7 +739,7 @@ fast hardware. SSL/TLS authentication must be used in this mode.
 
 --vlan-pvid v
   Specifies which VLAN identifier a "port" is associated with. Only valid
-  when ``--vlan-tagging`` is speficied.
+  when ``--vlan-tagging`` is specified.
 
   In the client context, the setting specifies which VLAN ID a client is
   associated with. In the global context, the VLAN ID of the server TAP

--- a/doc/man-sections/vpn-network-options.rst
+++ b/doc/man-sections/vpn-network-options.rst
@@ -548,7 +548,7 @@ routing.
   It's best to use the ``--fragment`` and/or ``--mssfix`` options to deal
   with MTU sizing issues.
 
-  Note: Depending on the platform, the operating system allows to receive
+  Note: Depending on the platform, the operating system allows one to receive
   packets larger than ``tun-mtu`` (e.g. Linux and FreeBSD) but other platforms
   (like macOS) limit received packets to the same size as the MTU.
 

--- a/src/openvpn/options.c
+++ b/src/openvpn/options.c
@@ -591,7 +591,7 @@ static const char usage_message[] =
     "                  Windows Certificate System Store.\n"
 #endif
     "--tls-cipher l  : A list l of allowable TLS ciphers separated by : (optional).\n"
-    "--tls-ciphersuites l: A list of allowed TLS 1.3 cipher suites seperated by : (optional)\n"
+    "--tls-ciphersuites l: A list of allowed TLS 1.3 cipher suites separated by : (optional)\n"
     "                : Use --show-tls to see a list of supported TLS ciphers (suites).\n"
     "--tls-cert-profile p : Set the allowed certificate crypto algorithm profile\n"
     "                  (default=legacy).\n"


### PR DESCRIPTION
Addressed typographical errors found in several documentation files to enhance overall clarity and readability.

Additionally, I'm suggesting these changes in response to lintian warnings generated by the **Debian** packaging process during the package update. This not only ensures compliance with Debian packaging standards but also provides valuable feedback to the upstream maintainers, highlighting improvements made downstream.