### PR TITLE
protocol_dump: tls-crypt support

### DIFF
--- a/src/openvpn/openvpn.h
+++ b/src/openvpn/openvpn.h
@@ -544,7 +544,8 @@ struct context
 #define PROTO_DUMP(buf, gc) protocol_dump((buf), \
                                           PROTO_DUMP_FLAGS   \
                                           |(c->c2.tls_multi ? PD_TLS : 0)   \
-                                          |(c->options.tls_auth_file ? md_kt_size(c->c1.ks.key_type.digest) : 0), \
+                                          |(c->options.tls_auth_file ? md_kt_size(c->c1.ks.key_type.digest) : 0) \
+                                          |(c->options.tls_crypt_file || c->options.tls_crypt_v2_file ? PD_TLS_CRYPT : 0), \
                                           gc)
 
 /* this represents "disabled peer-id" */

--- a/src/openvpn/ssl.h
+++ b/src/openvpn/ssl.h
@@ -525,6 +525,7 @@ tls_set_single_session(struct tls_multi *multi)
 #define PD_SHOW_DATA               (1<<8)
 #define PD_TLS                     (1<<9)
 #define PD_VERBOSE                 (1<<10)
+#define PD_TLS_CRYPT               (1<<11)
 
 const char *protocol_dump(struct buffer *buffer,
                           unsigned int flags,


### PR DESCRIPTION
Fixes #440

There are perhaps some silly choices to show the ACK list as `[ENCRYPTED]` etc.