### PR TITLE
Update documentation references in systemd unit files

### DIFF
--- a/distro/systemd/Makefile.am
+++ b/distro/systemd/Makefile.am
@@ -9,7 +9,10 @@
 #
 
 %.service: %.service.in Makefile
-	$(AM_V_GEN)sed -e 's|\@sbindir\@|$(sbindir)|' \
+	$(AM_V_GEN)sed \
+		-e 's|\@OPENVPN_VERSION_MAJOR\@|$(OPENVPN_VERSION_MAJOR)|g' \
+		-e 's|\@OPENVPN_VERSION_MINOR\@|$(OPENVPN_VERSION_MINOR)|g' \
+		-e 's|\@sbindir\@|$(sbindir)|g' \
 		$< > $@.tmp && mv $@.tmp $@
 
 EXTRA_DIST = \

--- a/distro/systemd/openvpn-client@.service.in
+++ b/distro/systemd/openvpn-client@.service.in
@@ -3,7 +3,7 @@ Description=OpenVPN tunnel for %I
 After=syslog.target network-online.target
 Wants=network-online.target
 Documentation=man:openvpn(8)
-Documentation=https://community.openvpn.net/openvpn/wiki/Openvpn24ManPage
+Documentation=https://openvpn.net/community-resources/reference-manual-for-openvpn-@OPENVPN_VERSION_MAJOR@-@OPENVPN_VERSION_MINOR@/
 Documentation=https://community.openvpn.net/openvpn/wiki/HOWTO
 
 [Service]

--- a/distro/systemd/openvpn-server@.service.in
+++ b/distro/systemd/openvpn-server@.service.in
@@ -3,7 +3,7 @@ Description=OpenVPN service for %I
 After=syslog.target network-online.target
 Wants=network-online.target
 Documentation=man:openvpn(8)
-Documentation=https://community.openvpn.net/openvpn/wiki/Openvpn24ManPage
+Documentation=https://openvpn.net/community-resources/reference-manual-for-openvpn-@OPENVPN_VERSION_MAJOR@-@OPENVPN_VERSION_MINOR@/
 Documentation=https://community.openvpn.net/openvpn/wiki/HOWTO
 
 [Service]


### PR DESCRIPTION
The systemd unit files for both client and server were referencing outdated documentation as they were hard-coded to the OpenVPN 2.4.x release branch.

This PR replaces https://community.openvpn.net/openvpn/wiki/Openvpn24ManPage by

- https://openvpn.net/community-resources/reference-manual-for-openvpn-2-6/ and
- https://build.openvpn.net/man/openvpn-2.6/openvpn.8.html

for the 2.6.x releases for example. The pair of major and minor version is now expanded from existing variables during build time.

I'm not sure whether those URLs are the preferred and right ones, but those were the ones I could find online providing up-to-date documentation.