### PR TITLE
Fix send_reliable array index in check_session_buf_not_used()

### DIFF
--- a/src/openvpn/ssl.c
+++ b/src/openvpn/ssl.c
@@ -3207,7 +3207,7 @@ check_session_buf_not_used(struct buffer *to_link, struct tls_session *session)
 
         for (int j = 0; j < ks->send_reliable->size; j++)
         {
-            if (ks->send_reliable->array[i].buf.data == dataptr)
+            if (ks->send_reliable->array[j].buf.data == dataptr)
             {
                 msg(M_INFO, "Warning buffer of freed TLS session is still in"
                     " use (session->key[%d].send_reliable->array[%d])",


### PR DESCRIPTION
A for loop within `check_session_buf_not_used()` uses `j` as an iterator, then checks the `send_reliable` array at index `i`. It should check at index `j` instead.