### PR TITLE
openvpn-[client|server].service: Remove syslog.target

### DIFF
--- a/distro/systemd/openvpn-client@.service.in
+++ b/distro/systemd/openvpn-client@.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=OpenVPN tunnel for %I
-After=syslog.target network-online.target
+After=network-online.target
 Wants=network-online.target
 Documentation=man:openvpn(8)
 Documentation=https://community.openvpn.net/openvpn/wiki/Openvpn24ManPage

--- a/distro/systemd/openvpn-server@.service.in
+++ b/distro/systemd/openvpn-server@.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=OpenVPN service for %I
-After=syslog.target network-online.target
+After=network-online.target
 Wants=network-online.target
 Documentation=man:openvpn(8)
 Documentation=https://community.openvpn.net/openvpn/wiki/Openvpn24ManPage


### PR DESCRIPTION
This target hasn't existed for over a decade

https://github.com/systemd/systemd/blob/6aa8d43ade72e24c9426e604f7fc4b7582b9db7c/NEWS#L72-L73

I attempted to email this change like it's the 1990s as per the template, but got a rejection back and I unfortunately don't have the time to fight with mailing lists to send two lines of removal patches.