### PR TITLE
support freebsd's fib feature

### DIFF
--- a/src/openvpn/tun.c
+++ b/src/openvpn/tun.c
@@ -55,6 +55,11 @@
 
 #include <string.h>
 
+#ifdef TARGET_FREEBSD
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#endif
+
 #ifdef _WIN32
 
 const static GUID GUID_DEVCLASS_NET = { 0x4d36e972L, 0xe325, 0x11ce, { 0xbf, 0xc1, 0x08, 0x00, 0x2b, 0xe1, 0x03, 0x18 } };
@@ -1169,14 +1174,43 @@ do_ifconfig_ipv6(struct tuntap *tt, const char *ifname, int tun_mtu,
         openvpn_execve_check(&argv, es, 0, "Solaris ifconfig IPv6 mtu failed");
     }
 #elif defined(TARGET_OPENBSD) || defined(TARGET_NETBSD) \
-    || defined(TARGET_DARWIN) || defined(TARGET_FREEBSD) \
-    || defined(TARGET_DRAGONFLY)
+    || defined(TARGET_DARWIN) || defined(TARGET_DRAGONFLY)
     argv_printf(&argv, "%s %s inet6 %s/%d mtu %d up", IFCONFIG_PATH, ifname,
                 ifconfig_ipv6_local, tt->netbits_ipv6, tun_mtu);
     argv_msg(M_INFO, &argv);
 
     openvpn_execve_check(&argv, es, S_FATAL,
                          "generic BSD ifconfig inet6 failed");
+
+#elif defined(TARGET_FREEBSD)
+    /* read current fib number, codes are from: */
+    /* https://github.com/freebsd/freebsd-src/blob/f9716eee8ab45ad906d9b5c5233ca20c10226ca7/sbin/route/route.c#L269 */
+    int numfibs = 0, defaultfib = 0;
+	size_t len = sizeof(numfibs);
+	if (sysctlbyname("net.fibs", (void *)&numfibs, &len, NULL, 0) == -1)
+		numfibs = -1;
+
+	len = sizeof(defaultfib);
+	if (numfibs != -1 &&
+	    sysctlbyname("net.my_fibnum", (void *)&defaultfib, &len, NULL,
+		0) == -1)
+		defaultfib = -1;
+
+    if (defaultfib <= 0)
+    {
+        argv_printf(&argv, "%s %s inet6 %s/%d mtu %d up", IFCONFIG_PATH, ifname,
+                    ifconfig_ipv6_local, tt->netbits_ipv6, tun_mtu);
+    }
+    else
+    {
+        argv_printf(&argv, "%s %s inet6 %s/%d mtu %d up fib %d", IFCONFIG_PATH, ifname,
+                    ifconfig_ipv6_local, tt->netbits_ipv6, tun_mtu, defaultfib);
+    }
+
+    argv_msg(M_INFO, &argv);
+
+    openvpn_execve_check(&argv, es, S_FATAL,
+                         "FreeBSD ifconfig inet6 failed");
 
 #if defined(TARGET_FREEBSD) && __FreeBSD_version >= 1200000 \
     && __FreeBSD_version < 1300000
@@ -1557,7 +1591,7 @@ do_ifconfig_ipv4(struct tuntap *tt, const char *ifname, int tun_mtu,
         add_route(&r, tt, 0, NULL, es, NULL);
     }
 
-#elif defined(TARGET_FREEBSD) || defined(TARGET_DRAGONFLY)
+#elif defined(TARGET_DRAGONFLY)
 
     /* example: ifconfig tun2 10.2.0.2 10.2.0.1 mtu 1450 netmask 255.255.255.255 up */
     if (tun)       /* point-to-point tun */
@@ -1571,6 +1605,55 @@ do_ifconfig_ipv4(struct tuntap *tt, const char *ifname, int tun_mtu,
         int netbits = netmask_to_netbits2(tt->remote_netmask);
         argv_printf(&argv, "%s %s %s/%d mtu %d up", IFCONFIG_PATH,
                     ifname, ifconfig_local, netbits, tun_mtu );
+    }
+
+    argv_msg(M_INFO, &argv);
+    openvpn_execve_check(&argv, es, S_FATAL, "DragonflyBSD ifconfig failed");
+
+#elif defined(TARGET_FREEBSD)
+
+    /* read current fib number, codes are from: */
+    /* https://github.com/freebsd/freebsd-src/blob/f9716eee8ab45ad906d9b5c5233ca20c10226ca7/sbin/route/route.c#L269 */
+    int numfibs = 0, defaultfib = 0;
+	size_t len = sizeof(numfibs);
+	if (sysctlbyname("net.fibs", (void *)&numfibs, &len, NULL, 0) == -1)
+		numfibs = -1;
+
+	len = sizeof(defaultfib);
+	if (numfibs != -1 &&
+	    sysctlbyname("net.my_fibnum", (void *)&defaultfib, &len, NULL,
+		0) == -1)
+		defaultfib = -1;
+
+    /* example: ifconfig tun2 10.2.0.2 10.2.0.1 mtu 1450 netmask 255.255.255.255 up */
+    if (tun)       /* point-to-point tun */
+    {
+        if (defaultfib <= 0)
+        {
+            argv_printf(&argv, "%s %s %s %s mtu %d netmask 255.255.255.255 up",
+                        IFCONFIG_PATH, ifname, ifconfig_local,
+                        ifconfig_remote_netmask, tun_mtu);
+        }
+        else
+        {
+            argv_printf(&argv, "%s %s %s %s mtu %d netmask 255.255.255.255 up fib %d",
+                        IFCONFIG_PATH, ifname, ifconfig_local,
+                        ifconfig_remote_netmask, tun_mtu, defaultfib);
+        }
+    }
+    else            /* tun with topology subnet and tap mode (always subnet) */
+    {
+        int netbits = netmask_to_netbits2(tt->remote_netmask);
+        if (defaultfib <= 0)
+        {
+            argv_printf(&argv, "%s %s %s/%d mtu %d up", IFCONFIG_PATH,
+                        ifname, ifconfig_local, netbits, tun_mtu );
+        }
+        else
+        {
+            argv_printf(&argv, "%s %s %s/%d mtu %d up fib %d", IFCONFIG_PATH,
+                        ifname, ifconfig_local, netbits, tun_mtu, defaultfib);
+        }
     }
 
     argv_msg(M_INFO, &argv);


### PR DESCRIPTION
This patch is to support FreeBSD's FIB feature.

When using FreeBSD's `setfib` command to launch OpenVPN in other FIB (routing table), the interface's IP address was not added to correct routing table, and then the routing entries couldn't be added successfully:
https://forums.freebsd.org/threads/freebsd-14-and-route-in-non-zero-fib.91099/
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=278295

This is duo to `ifconfig` command does not retrieve FIB number of current envirnment which is set by `setfib`. It only accepts `fib N` parameter.
`route` command can retrieve FIB number of current envirnment, the following routing entries will be added to correct routing table. But if the interface's IP address was not added correct routing table, `route` command will fail.