### PR TITLE
fix error "UDPv6: Can't assign requested address (code=49)"

### DIFF
--- a/src/openvpn/socket.c
+++ b/src/openvpn/socket.c
@@ -3481,7 +3481,7 @@ link_socket_write_udp_posix_sendmsg(struct link_socket *sock,
             cmsg->cmsg_type = IPV6_PKTINFO;
 
             pkti6 = (struct in6_pktinfo *) CMSG_DATA(cmsg);
-            pkti6->ipi6_ifindex = to->pi.in6.ipi6_ifindex;
+            pkti6->ipi6_ifindex = 0;
             pkti6->ipi6_addr = to->pi.in6.ipi6_addr;
             break;
         }


### PR DESCRIPTION
This bug appears when you let the openvpn server in "multihome" configuration, preventing the connexion to be established.

Related to and fixed by user hashiz in openvpn community but not yet implemented.

https://community.openvpn.net/openvpn/attachment/ticket/874/patch-src-openvpn-socket.c

Tested this fix on my setup with success

# Thank you for your contribution

You are welcome to open PR, but they are used for discussion only. All
patches must eventually go to the openvpn-devel mailing list for review:

* https://lists.sourceforge.net/lists/listinfo/openvpn-devel

Please send your patch using [git-send-email](https://git-scm.com/docs/git-send-email). For example to send your latest commit to the list:

    $ git send-email --to=openvpn-devel@lists.sourceforge.net HEAD~1

For details, see these Wiki articles:

* https://community.openvpn.net/openvpn/wiki/DeveloperDocumentation
* https://community.openvpn.net/openvpn/wiki/Contributing
