### PR TITLE
backport the security patch of CVE-2024-28882

### DIFF
--- a/src/openvpn/forward.c
+++ b/src/openvpn/forward.c
@@ -478,15 +478,22 @@ check_server_poll_timeout(struct context *c)
 /*
  * Schedule a signal n_seconds from now.
  */
-void
-schedule_exit(struct context *c, const int n_seconds, const int signal)
+bool
+schedule_exit(struct context *c)
 {
+    const int n_seconds = c->options.scheduled_exit_interval;
+    /* don't reschedule if already scheduled. */
+    if (event_timeout_defined(&c->c2.scheduled_exit))
+    {
+        return false;
+    }
     tls_set_single_session(c->c2.tls_multi);
     update_time();
     reset_coarse_timers(c);
     event_timeout_init(&c->c2.scheduled_exit, n_seconds, now);
-    c->c2.scheduled_exit_signal = signal;
+    c->c2.scheduled_exit_signal = SIGTERM;
     msg(D_SCHED_EXIT, "Delayed exit in %d seconds", n_seconds);
+    return true;
 }
 
 /*

--- a/src/openvpn/forward.h
+++ b/src/openvpn/forward.h
@@ -328,7 +328,7 @@ send_control_channel_string_dowork(struct tls_multi *multi,
 void process_ip_header(struct context *c, unsigned int flags, struct buffer *buf);
 
 #if P2MP
-void schedule_exit(struct context *c, const int n_seconds, const int signal);
+bool schedule_exit(struct context *c);
 
 #endif
 

--- a/src/openvpn/push.c
+++ b/src/openvpn/push.c
@@ -265,7 +265,7 @@ send_auth_failed(struct context *c, const char *client_reason)
     static const char auth_failed[] = "AUTH_FAILED";
     size_t len;
 
-    schedule_exit(c, c->options.scheduled_exit_interval, SIGTERM);
+    schedule_exit(c);
 
     len = (client_reason ? strlen(client_reason)+1 : 0) + sizeof(auth_failed);
     if (len > PUSH_BUNDLE_SIZE)
@@ -316,7 +316,7 @@ send_auth_pending_messages(struct context *c, const char *extra)
 void
 send_restart(struct context *c, const char *kill_msg)
 {
-    schedule_exit(c, c->options.scheduled_exit_interval, SIGTERM);
+    schedule_exit(c);
     send_control_channel_string(c, kill_msg ? kill_msg : "RESTART", D_PUSH);
 }
 


### PR DESCRIPTION
Here is a vulnerability which is fixed in the master branch https://github.com/OpenVPN/openvpn/commit/55bb3260c12bae33b6a8eac73cbb6972f8517411, but is not fixed in the branch of release/2.5, maybe it should be backported?