### PR TITLE
console_systemd: remove the timeout when using `systemd-ask-password`

### DIFF
--- a/src/openvpn/console_systemd.c
+++ b/src/openvpn/console_systemd.c
@@ -71,6 +71,7 @@ get_console_input_systemd(const char *prompt, const bool echo, char *input, cons
     }
 #endif
     argv_printf_cat(&argv, "--icon network-vpn");
+    argv_printf_cat(&argv, "--timeout=0");
     argv_printf_cat(&argv, "%s", prompt);
 
     if ((std_out = openvpn_popen(&argv, NULL)) < 0)


### PR DESCRIPTION
Without this, the password request will expire after 90 seconds leaving no way to provide the password without OpenVPN asking for it again. Given that interactive use will wait for input without a timeout, it makes sense to have non-interactive usage also wait until the user is ready instead of forcing users to race against the timeout.

# Thank you for your contribution

You are welcome to open PR, but they are used for discussion only. All
patches must eventually go to the openvpn-devel mailing list for review:

* https://lists.sourceforge.net/lists/listinfo/openvpn-devel

Please send your patch using [git-send-email](https://git-scm.com/docs/git-send-email). For example to send your latest commit to the list:

    $ git send-email --to=openvpn-devel@lists.sourceforge.net HEAD~1

For details, see these Wiki articles:

* https://community.openvpn.net/openvpn/wiki/DeveloperDocumentation
* https://community.openvpn.net/openvpn/wiki/Contributing
