### PR TITLE
dco: fix source IP selection

### DIFF
--- a/src/openvpn/dco.c
+++ b/src/openvpn/dco.c
@@ -562,7 +562,7 @@ dco_multi_get_localaddr(struct multi_context *m, struct multi_instance *mi,
         {
             struct sockaddr_in *sock_in4 = (struct sockaddr_in *)local;
 #if defined(HAVE_IN_PKTINFO) && defined(HAVE_IPI_SPEC_DST)
-            sock_in4->sin_addr = actual->pi.in4.ipi_addr;
+            sock_in4->sin_addr = actual->pi.in4.ipi_spec_dst;
 #elif defined(IP_RECVDSTADDR)
             sock_in4->sin_addr = actual->pi.in4;
 #else


### PR DESCRIPTION
If the local option is present, DCO should use it as the source IP, or Linux may pick a different IP as the source IP, breaking the connection.