### PR TITLE
Remove unnecessary route delay for Windows 7 and newer.

### DIFF
--- a/src/openvpn/options.c
+++ b/src/openvpn/options.c
@@ -3238,18 +3238,6 @@ options_postprocess_mutate_invariant(struct options *options)
         options->tuntap_options.ip_win32_type = IPW32_SET_NETSH;
     }
 
-    if ((dev == DEV_TYPE_TUN || dev == DEV_TYPE_TAP) && !options->route_delay_defined)
-    {
-        /* delay may only be necessary when we perform DHCP handshake */
-        const bool dhcp = (options->tuntap_options.ip_win32_type == IPW32_SET_DHCP_MASQ)
-                          || (options->tuntap_options.ip_win32_type == IPW32_SET_ADAPTIVE);
-        if ((options->mode == MODE_POINT_TO_POINT) && dhcp && (win32_version_info() <= WIN_VISTA))
-        {
-            options->route_delay_defined = true;
-            options->route_delay = 5; /* Vista sometimes has a race without this */
-        }
-    }
-
     if (options->ifconfig_noexec)
     {
         options->tuntap_options.ip_win32_type = IPW32_SET_MANUAL;


### PR DESCRIPTION
This PR considers removing a 5 second delay on Windows when setting up the tunnel.  We have been using this change for 3+ years in the Windscribe desktop app on Windows 10/11, with no adverse impact.

# Thank you for your contribution

You are welcome to open PR, but they are used for discussion only. All
patches must eventually go to the openvpn-devel mailing list for review:

* https://lists.sourceforge.net/lists/listinfo/openvpn-devel

Please send your patch using [git-send-email](https://git-scm.com/docs/git-send-email). For example to send your latest commit to the list:

    $ git send-email --to=openvpn-devel@lists.sourceforge.net HEAD~1

For details, see these Wiki articles:

* https://community.openvpn.net/openvpn/wiki/DeveloperDocumentation
* https://community.openvpn.net/openvpn/wiki/Contributing
