### PR TITLE
crypto: Improve AEAD cipher detection logic in `cipher_kt_mode_aead()`

### DIFF
--- a/src/openvpn/crypto_openssl.c
+++ b/src/openvpn/crypto_openssl.c
@@ -821,15 +821,16 @@ cipher_kt_mode_aead(const char *ciphername)
     evp_cipher_type *cipher = cipher_get(ciphername);
     if (cipher)
     {
-        if (EVP_CIPHER_mode(cipher) == OPENVPN_MODE_GCM)
+        int flags = EVP_CIPHER_flags(cipher);
+        if (flags & EVP_CIPH_FLAG_AEAD_CIPHER)
         {
             isaead = true;
         }
 
-#ifdef NID_chacha20_poly1305
+#if defined(NID_chacha20_poly1305) && OPENSSL_VERSION_NUMBER < 0x30000000L
         if (EVP_CIPHER_nid(cipher) == NID_chacha20_poly1305)
         {
-            isaead =  true;
+            isaead = true;
         }
 #endif
     }


### PR DESCRIPTION
This PR improves AEAD cipher detection in cipher_kt_mode_aead() by replacing the GCM-only mode check with a more reliable flag-based approach using EVP_CIPH_FLAG_AEAD_CIPHER, consistent with cipher_ctx_mode_aead(). It also refines ChaCha20-Poly1305 handling to apply only on OpenSSL versions prior to 3.0.0.

These changes enable support for a broader range of AEAD algorithms—such as AES-OCB, AES-EAX, Kuznyechik-MGM, and others—that were previously unsupported due to narrow detection logic. This makes AEAD handling more robust and future-proof, improving compatibility with OpenSSL 3.x and beyond.