### PR TITLE
Update systemd service name param to match command

### DIFF
--- a/distro/systemd/openvpn-client@.service.in
+++ b/distro/systemd/openvpn-client@.service.in
@@ -1,5 +1,5 @@
 [Unit]
-Description=OpenVPN tunnel for %I
+Description=OpenVPN tunnel for %i
 After=network-online.target
 Wants=network-online.target
 Documentation=man:openvpn(8)

--- a/distro/systemd/openvpn-server@.service.in
+++ b/distro/systemd/openvpn-server@.service.in
@@ -1,5 +1,5 @@
 [Unit]
-Description=OpenVPN service for %I
+Description=OpenVPN service for %i
 After=network-online.target
 Wants=network-online.target
 Documentation=man:openvpn(8)


### PR DESCRIPTION
The service name displays `%I` which invokes systemd's path mangling (notably, converting `-` to `/`), suggesting you need to provide an encoded parameter (via e.g. `systemd-escape`), but the start command itself uses `%i` which doesn't do the conversion.

This updates the service name to match the start command.

---

Raising here first as I'm not sure what (if anything) else needs doing past modifying the service templates.

# Thank you for your contribution

You are welcome to open PR, but they are used for discussion only. All
patches must eventually go to the openvpn-devel mailing list for review:

* https://lists.sourceforge.net/lists/listinfo/openvpn-devel

Please send your patch using [git-send-email](https://git-scm.com/docs/git-send-email). For example to send your latest commit to the list:

    $ git send-email --to=openvpn-devel@lists.sourceforge.net HEAD~1

For details, see these Wiki articles:

* https://community.openvpn.net/openvpn/wiki/DeveloperDocumentation
* https://community.openvpn.net/openvpn/wiki/Contributing
