### PR TITLE
ssl_openssl: Fix some CRL mixups

### DIFF
--- a/src/openvpn/openssl_compat.h
+++ b/src/openvpn/openssl_compat.h
@@ -52,21 +52,6 @@
 
 /* Functionality missing in LibreSSL before 3.5 */
 #if defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x3050000fL
-/**
- * Destroy a X509 object
- *
- * @param obj                X509 object
- */
-static inline void
-X509_OBJECT_free(X509_OBJECT *obj)
-{
-    if (obj)
-    {
-        X509_OBJECT_free_contents(obj);
-        OPENSSL_free(obj);
-    }
-}
-
 #define EVP_CTRL_AEAD_SET_TAG EVP_CTRL_GCM_SET_TAG
 #define EVP_CTRL_AEAD_GET_TAG EVP_CTRL_GCM_GET_TAG
 #endif

--- a/src/openvpn/ssl_openssl.h
+++ b/src/openvpn/ssl_openssl.h
@@ -41,6 +41,7 @@ struct tls_root_ctx
     SSL_CTX *ctx;
     time_t crl_last_mtime;
     off_t crl_last_size;
+    STACK_OF(X509_CRL) *crls;
 };
 
 struct key_state_ssl

--- a/src/openvpn/ssl_verify_openssl.c
+++ b/src/openvpn/ssl_verify_openssl.c
@@ -783,23 +783,7 @@ tls_verify_crl_missing(const struct tls_options *opt)
         return false;
     }
 
-    X509_STORE *store = SSL_CTX_get_cert_store(opt->ssl_ctx.ctx);
-    if (!store)
-    {
-        crypto_msg(M_FATAL, "Cannot get certificate store");
-    }
-
-    STACK_OF(X509_OBJECT) *objs = X509_STORE_get0_objects(store);
-    for (int i = 0; i < sk_X509_OBJECT_num(objs); i++)
-    {
-        X509_OBJECT *obj = sk_X509_OBJECT_value(objs, i);
-        ASSERT(obj);
-        if (X509_OBJECT_get_type(obj) == X509_LU_CRL)
-        {
-            return false;
-        }
-    }
-    return true;
+    return opt->ssl_ctx.crls == NULL || sk_X509_CRL_num(opt->ssl_ctx.crls) == 0;
 }
 
 #endif /* defined(ENABLE_CRYPTO_OPENSSL) */


### PR DESCRIPTION
Hi all! I tried to send this to openvpn-devel but it looks like it might not have gotten through? (I'm probably confused or just did something wrong.) It sounds like you all do look at GitHub though, so I figure I'll start here and we can figure out the mailing list step afterwards?

I've tested this by making sure things build and that the tests pass. However, it looks like some tests were skipped because they require manually configuring some things in ways I hadn't figured out. It's also unclear to me how well-tested CRL support is. There's no mention of CRLs in the tests directory. I'm not sure how you all test CRL-related changes.

---

There are two ways to load CRLs in OpenSSL. They can be loaded at the `X509_STORE`, shared across verifications, or loaded per verification at the `X509_STORE_CTX`.

OpenVPN currently does the former. However, it also supports CRL reloading, and tries to reload the CRL file before each connection. OpenSSL does not really have a good way to unload objects from an `X509_STORE`. OpenVPN currently does it by grabbing the `STACK_OF(X509_OBJECT)` out of the `X509_STORE` and manually deleting all the CRLs from it.

This mutates an OpenSSL internal object which bumps into problems if OpenSSL ever switches to a more efficient representation. See https://github.com/openssl/openssl/pull/28599

(It's also not thread-safe, though it doesn't look like that impacts OpenVPN? Actually even reading that list doesn't work. See CVE-2024-0397. This OpenSSL API was simply broken.)

Additionally, this seems to cause two OpenVPN features to not work together. I gather `backend_tls_ctx_reload_crl` is trying to clear the CRLs loaded from last time it ran. But `tls_ctx_load_ca` with a ca_file can also load CRLs. `tls_ctx_load_ca` with ca_path will also pick up CRLs and `backend_tls_ctx_reload_crl` actually ends up clobbering some state `X509_LOOKUP_hash_dir` internally maintains on the `X509_STORE`. Likewise, `tls_verify_crl_missing` can get confused between `backend_tls_ctx_reload_crl`'s crl_file-based CRLs and CRLs from `tls_ctx_load_ca`.

Avoid all this by tracking the two CRLs separately. `crl_file`-based CRLs now go onto a `STACK_OF(X509_CRL)` tracked on the `tls_root_ctx`. Now this field can be freely reloaded by OpenVPN without reconfiguring OpenSSL. Instead, pass the current value into OpenSSL at verification time.  To do so, we need to use `SSL_CTX_set_cert_verify_callback`, which allows swapping out the `X509_verify_cert` call, and also tweaking the `X509_STORE_CTX` configuration before starting certificate verification.

Context: `SSL_CTX_set_cert_verify_callback` and the existing verify_callback are not the same. `SSL_CTX_set_cert_verify_callback` wraps the verification while `verify_callback` is called multiple times throughout verification. It's too late to reconfigure `X509_STORE_CTX` in `verify_callback`. `verify_callback` is usually not what you want. Sometimes `current_cert` and `error_depth` don't quite line up, and `cert_hash_remember` may end up called multiple times for a single certificate.

I suspect some of the other `verify_callback` logic would also be better done in the new callback, but I've left it alone to keep this change minimal. `verify_callback` is really only usable for suppressing errors. Application bookkeeping is better done elsewhere.