### PR TITLE
Invalid Index - Bug Fix

### DIFF
--- a/src/openvpn/ssl.c
+++ b/src/openvpn/ssl.c
@@ -3679,7 +3679,7 @@ tls_pre_decrypt(struct tls_multi *multi, const struct link_socket_actual *from, 
      * multi->session: Possible initial packet. New sessions always start
      * as TM_INITIAL
      */
-    if (i == TM_SIZE && is_hard_reset_method2(op))
+    if (i == TM_SIZE || is_hard_reset_method2(op))
     {
         /*
          * No match with existing sessions,


### PR DESCRIPTION
Observed that there is an edge case where if the session ID is not found (i==3) && it is not a hard reset then the code path will then enter into the else block with (i==TM_SIZE==3) and enter into the multi->session[i] array (session[TM_SIZE]) which is an invalid index access!