### PR TITLE
Free Zero - Code Quality

### DIFF
--- a/src/openvpn/ssl.c
+++ b/src/openvpn/ssl.c
@@ -1054,7 +1054,7 @@ tls_session_free(struct tls_session *session, bool clear)
         /* we don't need clear=true for this call since
          * the structs are part of session and get cleared
          * as part of session */
-        key_state_free(&session->key[i], false);
+        key_state_free(&session->key[i], true);
     }
 
     free(session->common_name);


### PR DESCRIPTION
Created an example reference pull request where if the key is not zero'd out on tls_session_free then there is a potential risk that if it is ever called twice it could cause a crash: Example PR: https://github.com/OpenVPN/openvpn/pull/907