### PR TITLE
Init Free - Example Crash

### DIFF
--- a/src/openvpn/ssl.c
+++ b/src/openvpn/ssl.c
@@ -898,6 +898,12 @@ key_state_init(struct tls_session *session, struct key_state *ks)
 static void
 key_state_free(struct key_state *ks, bool clear)
 {
+    msg(M_INFO, "DEBUG KEY FREE PTR [%p][%p][%p][%p] [%p][%p][%p] [%p][%p][%p] [%p][%p][%p]",
+        ks->ks_ssl.ssl, ks->ks_ssl.ssl_bio, ks->ks_ssl.ct_in, ks->ks_ssl.ct_out,
+        ks->plaintext_read_buf.data, ks->plaintext_write_buf.data, ks->ack_write_buf.data,
+        ks->rec_ack, ks->lru_acks, ks->key_src,
+        ks->send_reliable, ks->rec_reliable, ks->paybuf);
+
     ks->state = S_UNDEF;
 
     key_state_ssl_free(&ks->ks_ssl);
@@ -1172,6 +1178,13 @@ tls_multi_init_finalize(struct tls_multi *multi, int tls_mtu)
     /* initialize the active and untrusted sessions */
 
     tls_session_init(multi, &multi->session[TM_ACTIVE]);
+    tls_session_free(&multi->session[TM_ACTIVE], false);
+    tls_session_free(&multi->session[TM_ACTIVE], false);
+    tls_session_init(multi, &multi->session[TM_ACTIVE]);
+
+    tls_session_init(multi, &multi->session[TM_INITIAL]);
+    tls_session_free(&multi->session[TM_INITIAL], false);
+    tls_session_free(&multi->session[TM_INITIAL], false);
     tls_session_init(multi, &multi->session[TM_INITIAL]);
 }
 


### PR DESCRIPTION
Example danger of not zero'ing out the key on tls_session_free if it were to be called twice for whatever reason (this crash can be potentially prevented):

```
(gdb) run --proto tcp4 --remote 1.3.3.7 --port 1337 --dev tun9 --pull --persist-tun --tun-mtu 1500 --txqueuelen 9000 --mssfix 0 --disable-dco --tcp-queue-limit 256 --reneg-sec 30 --ca /root/pki/sig.pem --cert /root/pki/crt.pem --key /root/pki/crt.key --client --remote-cert-tls server --auth-user-pass /root/auth.txt --verb 1
Starting program: /tmp/tmp/openvpn-fork-init-free/src/openvpn/openvpn --proto tcp4 --remote 1.3.3.7 --port 1337 --dev tun9 --pull --persist-tun --tun-mtu 1500 --txqueuelen 9000 --mssfix 0 --disable-dco --tcp-queue-limit 256 --reneg-sec 30 --ca /root/pki/sig.pem --cert /root/pki/crt.pem --key /root/pki/crt.key --client --remote-cert-tls server --auth-user-pass /root/auth.txt --verb 1
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/aarch64-linux-gnu/libthread_db.so.1".
2025-11-17 12:00:39 Note: --cipher is not set. OpenVPN versions before 2.5 defaulted to BF-CBC as fallback when cipher negotiation failed in this case. If you need this fallback please add '--data-ciphers-fallback BF-CBC' to your configuration and/or add BF-CBC to --data-ciphers. E.g. --data-ciphers DEFAULT:BF-CBC
2025-11-17 12:00:39 WARNING: file '/root/auth.txt' is group or others accessible
2025-11-17 12:00:39 OpenVPN 2.7_rc2 aarch64-unknown-linux-gnu [SSL (OpenSSL)] [EPOLL] [MH/PKTINFO] [AEAD] [DCO]
2025-11-17 12:00:39 library versions: OpenSSL 3.5.3 16 Sep 2025
2025-11-17 12:00:39 DCO version: 6.17.0-6-generic #6-Ubuntu SMP PREEMPT_DYNAMIC Tue Oct  7 14:22:06 UTC 2025
2025-11-17 12:00:39 DEBUG KEY FREE PTR [0xaaaaaac44270][0xaaaaaac3ffe0][0xaaaaaac3d230][0xaaaaaac3ff50] [0xaaaaaac48140][0xaaaaaac48950][0xaaaaaac49160] [0xaaaaaac3b710][0xaaaaaac3f770][0xaaaaaac3e390] [0xaaaaaac47b00][0xaaaaaac47e20][(nil)]
2025-11-17 12:00:39 DEBUG KEY FREE PTR [(nil)][(nil)][(nil)][(nil)] [(nil)][(nil)][(nil)] [(nil)][(nil)][(nil)] [(nil)][(nil)][(nil)]
2025-11-17 12:00:39 DEBUG KEY FREE PTR [0xaaaaaac44270][0xaaaaaac3ffe0][0xaaaaaac3d230][0xaaaaaac3ff50] [(nil)][(nil)][(nil)] [0xaaaaaac3b710][0xaaaaaac3f770][0xaaaaaac3e390] [0xaaaaaac47b00][0xaaaaaac47e20][(nil)]

Program received signal SIGSEGV, Segmentation fault.
0x0000fffff78e52d0 in BIO_free () from /lib/aarch64-linux-gnu/libcrypto.so.3
(gdb) bt
#0  0x0000fffff78e52d0 in BIO_free () from /lib/aarch64-linux-gnu/libcrypto.so.3
#1  0x0000fffff78e6db8 [PAC] in BIO_free_all () from /lib/aarch64-linux-gnu/libcrypto.so.3
#2  0x0000aaaaaab2bd00 [PAC] in key_state_ssl_free (ks_ssl=0xaaaaaac41e80) at ssl_openssl.c:2202
#3  0x0000aaaaaab21a04 in key_state_free (ks=ks@entry=0xaaaaaac41e70, clear=clear@entry=false) at ssl.c:909
#4  0x0000aaaaaab21b90 in tls_session_free (session=0xaaaaaac41700, clear=false) at ssl.c:1063
#5  0x0000aaaaaab23ee4 in tls_multi_init_finalize (multi=0xaaaaaac41080, tls_mtu=<optimized out>) at ssl.c:1182
#6  0x0000aaaaaaaced3c in do_init_frame_tls (c=0xffffffffdcf0) at init.c:3456
#7  init_instance (c=c@entry=0xffffffffdcf0, env=env@entry=0xaaaaaabbd040, flags=flags@entry=4) at init.c:4603
#8  0x0000aaaaaaacfbdc in init_instance_handle_signals (c=0xffffffffdcf0, env=0xaaaaaabbd040, flags=4) at init.c:4732
#9  0x0000aaaaaaaee13c in tunnel_point_to_point (c=0xfffffffff040) at openvpn.c:66
#10 openvpn_main (argc=35, argv=0xfffffffff218) at openvpn.c:305
#11 0x0000aaaaaaaaca0c in main (argc=<optimized out>, argv=<optimized out>) at openvpn.c:384
(gdb) quit
```