### PR TITLE
Old/New IP - Logic Redo

### DIFF
--- a/src/openvpn/multi.c
+++ b/src/openvpn/multi.c
@@ -4377,20 +4377,26 @@ update_vhash(struct multi_context *m, struct multi_instance *mi, const char *new
 {
     if (new_ip)
     {
+        in_addr_t old_addr_t = mi->context.c2.push_ifconfig_local;
+
+        struct in_addr new_addr;
+        CLEAR(new_addr);
+        int addr_stat = inet_pton(AF_INET, new_ip, &new_addr);
+        in_addr_t new_addr_t = ntohl(new_addr.s_addr);
+
         /* Remove old IP */
-        if (mi->context.c2.push_ifconfig_defined)
+        if ((addr_stat != 1 || new_addr_t != old_addr_t)
+            && mi->context.c2.push_ifconfig_defined)
         {
             unlearn_ifconfig(m, mi);
         }
 
         /* Add new IP */
-        struct in_addr new_addr;
-        CLEAR(new_addr);
-        if (inet_pton(AF_INET, new_ip, &new_addr) == 1
-            && multi_learn_in_addr_t(m, mi, ntohl(new_addr.s_addr), -1, true))
+        if ((addr_stat == 1 && new_addr_t != old_addr_t)
+            && multi_learn_in_addr_t(m, mi, new_addr_t, -1, true))
         {
             mi->context.c2.push_ifconfig_defined = true;
-            mi->context.c2.push_ifconfig_local = ntohl(new_addr.s_addr);
+            mi->context.c2.push_ifconfig_local = new_addr_t;
             /* set our client's VPN endpoint for status reporting purposes */
             mi->reporting_addr = mi->context.c2.push_ifconfig_local;
         }
@@ -4398,16 +4404,21 @@ update_vhash(struct multi_context *m, struct multi_instance *mi, const char *new
 
     if (new_ipv6)
     {
+        struct in6_addr old_addr6 = mi->context.c2.push_ifconfig_ipv6_local;
+
+        struct in6_addr new_addr6;
+        CLEAR(new_addr6);
+        int addr6_stat = inet_pton(AF_INET6, new_ipv6, &new_addr6);
+
         /* Remove old IPv6 */
-        if (mi->context.c2.push_ifconfig_ipv6_defined)
+        if ((addr6_stat != 1 || memcmp(&new_addr6, &old_addr6, sizeof(old_addr6)) != 0)
+            && mi->context.c2.push_ifconfig_ipv6_defined)
         {
             unlearn_ifconfig_ipv6(m, mi);
         }
 
         /* Add new IPv6 */
-        struct in6_addr new_addr6;
-        CLEAR(new_addr6);
-        if (inet_pton(AF_INET6, new_ipv6, &new_addr6) == 1
+        if ((addr6_stat == 1 && memcmp(&new_addr6, &old_addr6, sizeof(old_addr6)) != 0)
             && multi_learn_in6_addr(m, mi, new_addr6, -1, true))
         {
             mi->context.c2.push_ifconfig_ipv6_defined = true;


### PR DESCRIPTION
There was an update pushed earlier this year which undid some important logic in terms of learning/unlearning the ifconfig IP address. The older original code would check that the new/old IPs don't match first before performing that logic. I believe this was important and correct because it could cause connection interruptions during the learn/unlearn process if the IP address has stayed the same!

```
commit 5e4c9a69eaf9d32e85613bd71ed219fdbb062d34
Author: Marco Baffo <marco@mandelbit.com>
Date:   Fri Oct 17 22:19:12 2025 +0200
...
-update_vhash(struct multi_context *m, struct multi_instance *mi, const char *old_ip, const char *old_ipv6)
+update_vhash(struct multi_context *m, struct multi_instance *mi, const char *new_ip, const char *new_ipv6)
 {
-    struct in_addr addr;
-    struct in6_addr new_ipv6;
-
-    if ((mi->context.options.ifconfig_local && (!old_ip || strcmp(old_ip, mi->context.options.ifconfig_local)))
-        && inet_pton(AF_INET, mi->context.options.ifconfig_local, &addr) == 1)
+    if (new_ip)
     {
```