### PR TITLE
PUSH_UPDATE: fix option reset logic in continuation messages

### DIFF
--- a/src/openvpn/options.h
+++ b/src/openvpn/options.h
@@ -558,6 +558,7 @@ struct options
     bool pull; /* client pull of config options from server */
     int push_continuation;
     unsigned int push_option_types_found;
+    unsigned int push_update_options_found; /* tracks which option types have been reset in current PUSH_UPDATE sequence */
     const char *auth_user_pass_file;
     bool auth_user_pass_file_inline;
     struct options_pre_connect *pre_connect;
@@ -863,14 +864,11 @@ void remove_option(struct context *c, struct options *options, char *p[], bool i
  * @param option_types_found A pointer to the variable where the flags corresponding to the options
  * found are stored.
  * @param es The environment set structure.
- * @param update_options_found A pointer to the variable where the flags corresponding to the update
- * options found are stored, used to check if an option of the same type has already been processed
- * by update_option() within the same push-update message.
  */
 void update_option(struct context *c, struct options *options, char *p[], bool is_inline,
                    const char *file, int line, const int level, const msglvl_t msglevel,
                    const unsigned int permission_mask, unsigned int *option_types_found,
-                   struct env_set *es, unsigned int *update_options_found);
+                   struct env_set *es);
 
 void parse_argv(struct options *options, const int argc, char *argv[], const msglvl_t msglevel,
                 const unsigned int permission_mask, unsigned int *option_types_found,

--- a/src/openvpn/options_parse.c
+++ b/src/openvpn/options_parse.c
@@ -517,7 +517,6 @@ apply_push_options(struct context *c, struct options *options, struct buffer *bu
     int line_num = 0;
     const char *file = "[PUSH-OPTIONS]";
     const msglvl_t msglevel = D_PUSH_ERRORS | M_OPTERR;
-    unsigned int update_options_found = 0;
 
     while (buf_parse(buf, ',', line, sizeof(line)))
     {
@@ -564,8 +563,13 @@ apply_push_options(struct context *c, struct options *options, struct buffer *bu
             }
             else
             {
+                /*
+                 * Use persistent push_update_options_found from options struct to track
+                 * which option types have been reset across continuation messages.
+                 * This prevents routes from being reset on each continuation message.
+                 */
                 update_option(c, options, p, false, file, line_num, 0, msglevel, permission_mask,
-                              option_types_found, es, &update_options_found);
+                              option_types_found, es);
             }
         }
     }

--- a/src/openvpn/push.c
+++ b/src/openvpn/push.c
@@ -540,11 +540,15 @@ incoming_push_message(struct context *c, const struct buffer *buffer)
             }
             else
             {
-                if (!option_types_found)
+                /* Clear push_update_options_found for next PUSH_UPDATE sequence */
+                c->options.push_update_options_found = 0;
+
+                /* Use accumulated option_types_found for the entire PUSH_UPDATE sequence */
+                if (!c->options.push_option_types_found)
                 {
                     msg(M_WARN, "No updatable options found in incoming PUSH_UPDATE message");
                 }
-                else if (!do_update(c, option_types_found))
+                else if (!do_update(c, c->options.push_option_types_found))
                 {
                     msg(D_PUSH_ERRORS, "Failed to update options");
                     goto error;

--- a/tests/unit_tests/openvpn/test_options_parse.c
+++ b/tests/unit_tests/openvpn/test_options_parse.c
@@ -60,7 +60,7 @@ void
 update_option(struct context *c, struct options *options, char *p[], bool is_inline,
               const char *file, int line, const int level, const msglvl_t msglevel,
               const unsigned int permission_mask, unsigned int *option_types_found,
-              struct env_set *es, unsigned int *update_options_found)
+              struct env_set *es)
 {
 }
 


### PR DESCRIPTION
Previously, the logic for resetting push options (like 'route') was based on `update_options_found` which was local to `apply_push_options`. This meant that if a PUSH_UPDATE was split across multiple continuation messages, the state was lost, causing routes to be reset multiple times (once per message chunk) rather than once per update sequence.

This patch moves the state tracking to `struct options` as `push_update_options_found`, allowing it to persist across the entire PUSH_UPDATE sequence.

This fixes an issue where large route lists sent via PUSH_UPDATE would result in only the last chunk's routes being applied, or previous routes being continuously deleted and re-added.

Added unit test `test_incoming_push_continuation_route_accumulation` to verify the fix.