### PR TITLE
dco: backport immediate message processing to 2.6

### DIFF
--- a/src/openvpn/dco.h
+++ b/src/openvpn/dco.h
@@ -129,12 +129,15 @@ int open_tun_dco(struct tuntap *tt, openvpn_net_ctx_t *ctx, const char *dev);
 void close_tun_dco(struct tuntap *tt, openvpn_net_ctx_t *ctx);
 
 /**
- * Read data from the DCO communication channel (i.e. a control packet)
+ * Read and process DCO messages from the kernel.
+ *
+ * Each message is processed immediately inside the netlink callback
+ * to prevent message loss when multiple notifications arrive simultaneously.
  *
  * @param dco       the DCO context
  * @return          0 on success or a negative error code otherwise
  */
-int dco_do_read(dco_context_t *dco);
+int dco_read_and_process(dco_context_t *dco);
 
 /**
  * Install a DCO in the main event loop
@@ -301,7 +304,7 @@ close_tun_dco(struct tuntap *tt, openvpn_net_ctx_t *ctx)
 }
 
 static inline int
-dco_do_read(dco_context_t *dco)
+dco_read_and_process(dco_context_t *dco)
 {
     ASSERT(false);
     return 0;

--- a/src/openvpn/dco_freebsd.c
+++ b/src/openvpn/dco_freebsd.c
@@ -559,7 +559,7 @@ dco_set_peer(dco_context_t *dco, unsigned int peerid,
 }
 
 int
-dco_do_read(dco_context_t *dco)
+dco_read_and_process(dco_context_t *dco)
 {
     struct ifdrv drv;
     uint8_t buf[4096];

--- a/src/openvpn/dco_linux.h
+++ b/src/openvpn/dco_linux.h
@@ -36,6 +36,9 @@
 typedef enum ovpn_key_slot dco_key_slot_t;
 typedef enum ovpn_cipher_alg dco_cipher_t;
 
+/* Forward declarations for callback context */
+struct multi_context;
+struct context;
 
 typedef struct
 {
@@ -47,6 +50,7 @@ typedef struct
 
     int ovpn_dco_id;
     int ovpn_dco_mcast_id;
+    int ctrlid;                      /* NLCTRL family ID for message routing */
 
     unsigned int ifindex;
 
@@ -55,6 +59,10 @@ typedef struct
     int dco_del_peer_reason;
     uint64_t dco_read_bytes;
     uint64_t dco_write_bytes;
+
+    /* Callback context for stats handlers */
+    struct multi_context *m;         /* For multi-peer stats */
+    struct context *c;               /* For single-peer stats */
 } dco_context_t;
 
 #endif /* defined(ENABLE_DCO) && defined(TARGET_LINUX) */

--- a/src/openvpn/dco_win.c
+++ b/src/openvpn/dco_win.c
@@ -423,7 +423,7 @@ dco_version_string(struct gc_arena *gc)
 }
 
 int
-dco_do_read(dco_context_t *dco)
+dco_read_and_process(dco_context_t *dco)
 {
     /* no-op on windows */
     ASSERT(0);

--- a/src/openvpn/forward.c
+++ b/src/openvpn/forward.c
@@ -1269,13 +1269,16 @@ extract_dco_float_peer_addr(const sa_family_t socket_family,
     }
 }
 
-static void
-process_incoming_dco(struct context *c)
+void
+process_incoming_dco(dco_context_t *dco)
 {
 #if defined(ENABLE_DCO) && (defined(TARGET_LINUX) || defined(TARGET_FREEBSD))
-    dco_context_t *dco = &c->c1.tuntap->dco;
-
-    dco_do_read(dco);
+    /* Get context from DCO context pointer set during initialization */
+    struct context *c = dco->c;
+    if (!c)
+    {
+        return;
+    }
 
     /* FreeBSD currently sends us removal notifcation with the old peer-id in
      * p2p mode with the ping timeout reason, so ignore that one to not shoot
@@ -2344,7 +2347,7 @@ process_io(struct context *c)
     {
         if (!IS_SIG(c))
         {
-            process_incoming_dco(c);
+            dco_read_and_process(&c->c1.tuntap->dco);
         }
     }
 }

--- a/src/openvpn/forward.h
+++ b/src/openvpn/forward.h
@@ -50,6 +50,7 @@
 #include "openvpn.h"
 #include "occ.h"
 #include "ping.h"
+#include "dco.h"
 
 #define IOW_TO_TUN          (1<<0)
 #define IOW_TO_LINK         (1<<1)
@@ -247,6 +248,17 @@ void read_incoming_tun(struct context *c);
  *     packet.
  */
 void process_incoming_tun(struct context *c);
+
+/**
+ * Process an incoming DCO message (from kernel space) for P2P mode.
+ *
+ * Called immediately from the netlink callback ovpn_handle_msg() to process
+ * each message as it arrives. This prevents message loss when multiple
+ * DEL_PEER notifications arrive simultaneously.
+ *
+ * @param dco - The DCO context containing the parsed message.
+ */
+void process_incoming_dco(dco_context_t *dco);
 
 
 /**

--- a/src/openvpn/init.c
+++ b/src/openvpn/init.c
@@ -1883,6 +1883,7 @@ do_open_tun(struct context *c, int *error_flags)
         if (dco_enabled(&c->options))
         {
             ovpn_dco_init(c->mode, &c->c1.tuntap->dco);
+            c->c1.tuntap->dco.c = c;  /* Link DCO context to main context for mode detection */
         }
 
         /* open the tun device */

--- a/src/openvpn/mtcp.c
+++ b/src/openvpn/mtcp.c
@@ -747,7 +747,7 @@ multi_tcp_process_io(struct multi_context *m)
             /* incoming data on DCO? */
             else if (e->arg == MTCP_DCO)
             {
-                multi_process_incoming_dco(m);
+                dco_read_and_process(&m->top.c1.tuntap->dco);
             }
 #endif
             /* signal received? */
@@ -803,6 +803,9 @@ tunnel_server_tcp(struct context *top)
 
     /* initialize global multi_context object */
     multi_init(&multi, top, true);
+
+    /* Link top context back to multi_context for DCO immediate processing */
+    top->multi = &multi;
 
     /* initialize our cloned top object */
     multi_top_init(&multi, top);

--- a/src/openvpn/mudp.c
+++ b/src/openvpn/mudp.c
@@ -409,11 +409,8 @@ multi_process_io_udp(struct multi_context *m)
     {
         if (!IS_SIG(&m->top))
         {
-            bool ret = true;
-            while (ret)
-            {
-                ret = multi_process_incoming_dco(m);
-            }
+            /* Single call handles all pending messages (processing in callback) */
+            dco_read_and_process(&m->top.c1.tuntap->dco);
         }
     }
 #endif
@@ -477,6 +474,9 @@ tunnel_server_udp(struct context *top)
 
     /* initialize global multi_context object */
     multi_init(&multi, top, false);
+
+    /* Link top context back to multi_context for DCO immediate processing */
+    top->multi = &multi;
 
     /* initialize our cloned top object */
     multi_top_init(&multi, top);

--- a/src/openvpn/multi.c
+++ b/src/openvpn/multi.c
@@ -3287,14 +3287,14 @@ process_incoming_del_peer(struct multi_context *m, struct multi_instance *mi,
     multi_signal_instance(m, mi, SIGTERM);
 }
 
-bool
-multi_process_incoming_dco(struct multi_context *m)
+void
+multi_process_incoming_dco(dco_context_t *dco)
 {
-    dco_context_t *dco = &m->top.c1.tuntap->dco;
+    /* Get multi_context from the context pointer set during initialization */
+    ASSERT(dco->c && dco->c->multi);
+    struct multi_context *m = dco->c->multi;
 
     struct multi_instance *mi = NULL;
-
-    int ret = dco_do_read(&m->top.c1.tuntap->dco);
 
     int peer_id = dco->dco_message_peer_id;
 
@@ -3303,7 +3303,7 @@ multi_process_incoming_dco(struct multi_context *m)
      */
     if (peer_id < 0)
     {
-        return ret > 0;
+        return;
     }
 
     if ((peer_id < m->max_clients) && (m->instances[peer_id]))
@@ -3356,7 +3356,6 @@ multi_process_incoming_dco(struct multi_context *m)
     dco->dco_del_peer_reason = -1;
     dco->dco_read_bytes = 0;
     dco->dco_write_bytes = 0;
-    return ret > 0;
 }
 #endif /* if defined(ENABLE_DCO) && defined(TARGET_LINUX) */
 

--- a/src/openvpn/multi.h
+++ b/src/openvpn/multi.h
@@ -40,6 +40,7 @@
 #include "perf.h"
 #include "vlan.h"
 #include "reflect_filter.h"
+#include "dco.h"
 
 #define MULTI_PREFIX_MAX_LENGTH 256
 
@@ -317,13 +318,13 @@ bool multi_process_post(struct multi_context *m, struct multi_instance *mi, cons
 /**
  * Process an incoming DCO message (from kernel space).
  *
- * @param m            - The single \c multi_context structur.e
+ * Called immediately from the netlink callback ovpn_handle_msg() to process
+ * each message as it arrives. This prevents message loss when multiple
+ * DEL_PEER notifications arrive simultaneously.
  *
- * @return
- *  - True, if the message was received correctly.
- *  - False, if there was an error while reading the message.
+ * @param dco          - The DCO context containing the parsed message.
  */
-bool multi_process_incoming_dco(struct multi_context *m);
+void multi_process_incoming_dco(dco_context_t *dco);
 
 /**************************************************************************/
 /**

--- a/src/openvpn/openvpn.h
+++ b/src/openvpn/openvpn.h
@@ -46,6 +46,9 @@
 #include "plugin.h"
 #include "manage.h"
 
+/* Forward declaration for multi-client context */
+struct multi_context;
+
 /*
  * Our global key schedules, packaged thusly
  * to facilitate --persist-key.
@@ -515,6 +518,9 @@ struct context
     struct context_0 *c0;       /**< Level 0 %context. */
     struct context_1 c1;        /**< Level 1 %context. */
     struct context_2 c2;        /**< Level 2 %context. */
+
+    struct multi_context *multi; /**< Pointer to the main P2MP context.
+                                  *   Non-NULL only when mode == CM_TOP. */
 };
 
 /*


### PR DESCRIPTION
Backport of commit 7791f5358a5574d4ef1bd27e2d52300c9d98bd72 from master.

Currently, reading and processing of incoming DCO messages are decoupled: notifications are read, parsed, and the relevant information is stored in fields of dco_context_t for later processing. This approach is problematic on Linux, since libnl does not allow reading a single netlink message at a time, which can result in loss of information when multiple notifications are available.

This change adopts a read -> parse -> process paradigm. On Linux, processing is now invoked directly from within the parsing callback.

On Linux, a DEL_PEER notification from the kernel triggers a GET_PEER request from userspace, which can lead to errors when multiple simultaneous DEL_PEER notifications are received. To avoid this, introduce a lock that prevents requesting stats while still busy parsing other messages.

Note: The 2.6 backport requires additional changes not present in the master commit because the multi context linkage infrastructure differs:
- Added multi pointer to struct context (openvpn.h)
- Set context linkages in init.c, mtcp.c, mudp.c
- Added dco_linux.h changes for context pointer

Reported-by: Stefan Baranoff <stefan.baranoff@trinitycyber.com>
Github: OpenVPN/openvpn#900
Github: OpenVPN/openvpn#918
Github: OpenVPN/openvpn#931
Github: fixes OpenVPN/openvpn#919
(backport of commit 7791f5358a5574d4ef1bd27e2d52300c9d98bd72)

# Thank you for your contribution

You are welcome to open PR, but they are used for discussion only. All
patches must eventually go to the openvpn-devel mailing list for review:

* https://lists.sourceforge.net/lists/listinfo/openvpn-devel

Please send your patch using [git-send-email](https://git-scm.com/docs/git-send-email). For example to send your latest commit to the list:

    $ git send-email --to=openvpn-devel@lists.sourceforge.net HEAD~1

For details, see these Wiki articles:

* https://community.openvpn.net/openvpn/wiki/DeveloperDocumentation
* https://community.openvpn.net/openvpn/wiki/Contributing
