### PR TITLE
Update route.c to add interface name for link-local ipv6 addresses ev…

### DIFF
--- a/src/openvpn/route.c
+++ b/src/openvpn/route.c
@@ -1825,14 +1825,21 @@ add_route_ipv6(struct route_ipv6 *r6, const struct tuntap *tt, unsigned int flag
      * but for link-local destinations, we MUST specify the interface, so
      * we build a combined "$gateway%$interface" gateway string
      */
-    if (r6->iface != NULL && gateway_needed
-        && IN6_IS_ADDR_LINKLOCAL(&r6->gateway)) /* fe80::...%intf */
-    {
-        size_t len = strlen(gateway) + 1 + strlen(r6->iface) + 1;
-        char *tmp = gc_malloc(len, true, &gc);
-        snprintf(tmp, len, "%s%%%s", gateway, r6->iface);
-        gateway = tmp;
-    }
+     if (IN6_IS_ADDR_LINKLOCAL(&r6->gateway)) {       /* fe80::...%intf */
+
+              if (r6->iface != NULL && gateway_needed) {
+                  size_t len = strlen(gateway) + 1 + strlen(r6->iface)+1;
+                  char *tmp = gc_malloc( len, true, &gc );
+                  snprintf( tmp, len, "%s%%%s", gateway, r6->iface );
+                  gateway = tmp;
+
+              } else if (device) {
+                          size_t len = strlen(gateway) + 1 + strlen(device)+1;
+                          char *tmp = gc_malloc( len, true, &gc );
+                          snprintf( tmp, len, "%s%%%s", gateway, device );
+                          gateway = tmp;
+                     }
+      }
 #endif
 
 #ifndef _WIN32


### PR DESCRIPTION
…en if it is not server special route

If a link-local ipv6 gateway is pushed by the server, openvpn client must append the interface name to the address even if this route is not considered as vpn special route.

# Thank you for your contribution

You are welcome to open PR, but they are used for discussion only. All
patches must eventually go to the openvpn-devel mailing list for review:

* https://lists.sourceforge.net/lists/listinfo/openvpn-devel

Please send your patch using [git-send-email](https://git-scm.com/docs/git-send-email). For example to send your latest commit to the list:

    $ git send-email --to=openvpn-devel@lists.sourceforge.net HEAD~1

For details, see these Wiki articles:

* https://community.openvpn.net/openvpn/wiki/DeveloperDocumentation
* https://community.openvpn.net/openvpn/wiki/Contributing
