### PR TITLE
Add --sni option for TLS Server Name Indication support

### DIFF
--- a/doc/man-sections/tls-options.rst
+++ b/doc/man-sections/tls-options.rst
@@ -408,6 +408,28 @@ certificates and keys: https://github.com/OpenVPN/easy-rsa
     but also the key exchange in TLS 1.3 and using this option improperly
     will disable TLS 1.3.
 
+--sni hostname
+    Set the TLS Server Name Indication (SNI) for the control channel TLS
+    handshake.
+
+    Valid syntax:
+    ::
+
+       sni auto
+       sni hostname
+
+    When set to :code:`auto`, the hostname from the ``--remote`` option is
+    used as the SNI hostname. Alternatively, an explicit hostname can be
+    specified.
+
+    SNI is a TLS extension that allows the client to indicate to the server
+    which hostname it is trying to connect to. This is useful when connecting
+    through proxies or load balancers that use SNI to route connections, or
+    when the server requires a specific SNI value to present the correct
+    certificate.
+
+    By default, no SNI is sent (for backwards compatibility).
+
 --tls-cert-profile profile
   Set the allowed cryptographic algorithms for certificates according to
   ``profile``.

--- a/src/openvpn/init.c
+++ b/src/openvpn/init.c
@@ -3351,6 +3351,11 @@ do_init_crypto_tls(struct context *c, const unsigned int flags)
     to.crl_file = options->crl_file;
     to.crl_file_inline = options->crl_file_inline;
     to.ssl_flags = options->ssl_flags;
+
+    /* SNI (Server Name Indication) for TLS handshake */
+    to.sni = options->sni;
+    to.remote = options->ce.remote;
+
     to.ns_cert_type = options->ns_cert_type;
     memcpy(to.remote_cert_ku, options->remote_cert_ku, sizeof(to.remote_cert_ku));
     to.remote_cert_eku = options->remote_cert_eku;

--- a/src/openvpn/options.c
+++ b/src/openvpn/options.c
@@ -609,6 +609,8 @@ static const char usage_message[] =
     "--tls-cipher l  : A list l of allowable TLS ciphers separated by : (optional).\n"
     "--tls-ciphersuites l: A list of allowed TLS 1.3 cipher suites separated by : (optional)\n"
     "                : Use --show-tls to see a list of supported TLS ciphers (suites).\n"
+    "--sni host      : Set TLS SNI (Server Name Indication) for the control channel.\n"
+    "                  Use 'auto' to use the remote hostname, or specify a hostname.\n"
     "--tls-cert-profile p : Set the allowed certificate crypto algorithm profile\n"
     "                  (default=legacy).\n"
     "--providers l   : A list l of OpenSSL providers to load.\n"
@@ -8803,6 +8805,11 @@ add_option(struct options *options, char *p[], bool is_inline, const char *file,
     {
         VERIFY_PERMISSION(OPT_P_GENERAL);
         options->tls_groups = p[1];
+    }
+    else if (streq(p[0], "sni") && p[1] && !p[2])
+    {
+        VERIFY_PERMISSION(OPT_P_GENERAL);
+        options->sni = p[1];
     }
     else if (streq(p[0], "crl-verify") && p[1] && ((p[2] && streq(p[2], "dir")) || !p[2]))
     {

--- a/src/openvpn/options.h
+++ b/src/openvpn/options.h
@@ -625,6 +625,9 @@ struct options
     bool verify_hash_no_ca;
     unsigned int ssl_flags; /* set to SSLF_x flags from ssl.h */
 
+    /* TLS SNI (Server Name Indication) - NULL=off, "auto"=use remote, otherwise explicit hostname */
+    const char *sni;
+
 #ifdef ENABLE_PKCS11
     const char *pkcs11_providers[MAX_PARMS];
     unsigned pkcs11_private_mode[MAX_PARMS];

--- a/src/openvpn/ssl_common.h
+++ b/src/openvpn/ssl_common.h
@@ -437,6 +437,12 @@ struct tls_options
 #define SSLF_TLS_DEBUG_ENABLED        (1u << 14)
     unsigned int ssl_flags;
 
+    /* SNI (Server Name Indication) - NULL=off, "auto"=use remote, or explicit hostname */
+    const char *sni;
+
+    /* Remote hostname from connection entry, used when sni="auto" */
+    const char *remote;
+
 #ifdef ENABLE_MANAGEMENT
     struct man_def_auth_context *mda_context;
 #endif

--- a/src/openvpn/ssl_openssl.c
+++ b/src/openvpn/ssl_openssl.c
@@ -2179,6 +2179,23 @@ key_state_ssl_init(struct key_state_ssl *ks_ssl, const struct tls_root_ctx *ssl_
     else
     {
         SSL_set_connect_state(ks_ssl->ssl);
+
+        /* Set SNI (Server Name Indication) if configured */
+        if (session->opt->sni)
+        {
+            const char *sni_hostname = session->opt->sni;
+
+            /* If sni is "auto", use the remote hostname */
+            if (streq(sni_hostname, "auto"))
+            {
+                sni_hostname = session->opt->remote;
+            }
+
+            if (sni_hostname && !SSL_set_tlsext_host_name(ks_ssl->ssl, sni_hostname))
+            {
+                crypto_msg(M_FATAL, "SSL_set_tlsext_host_name failed");
+            }
+        }
     }
 
     SSL_set_bio(ks_ssl->ssl, ks_ssl->ct_in, ks_ssl->ct_out);


### PR DESCRIPTION
Add support for sending SNI (Server Name Indication) during TLS handshake. The new --sni option accepts three modes:
- Not set: SNI disabled (default, backwards compatible)
- "auto": Use hostname from --remote directive
- <hostname>: Use specified hostname

Implementation covers both OpenSSL and mbedTLS backends.

# Thank you for your contribution

You are welcome to open PR, but they are used for discussion only. All
patches must eventually go to the openvpn-devel mailing list for review:

* https://lists.sourceforge.net/lists/listinfo/openvpn-devel

Please send your patch using [git-send-email](https://git-scm.com/docs/git-send-email). For example to send your latest commit to the list:

    $ git send-email --to=openvpn-devel@lists.sourceforge.net HEAD~1

For details, see these Wiki articles:

* https://community.openvpn.net/openvpn/wiki/DeveloperDocumentation
* https://community.openvpn.net/openvpn/wiki/Contributing
