### PR TITLE
Use memcmp_constant_time for SHA-256 hash comparisons

### DIFF
--- a/src/openvpn/init.c
+++ b/src/openvpn/init.c
@@ -31,6 +31,7 @@
 #endif
 
 #include "win32.h"
+#include "crypto.h"
 #include "init.h"
 #include "run_command.h"
 #include "sig.h"
@@ -2164,8 +2165,8 @@ static bool
 options_hash_changed_or_zero(const struct sha256_digest *a, const struct sha256_digest *b)
 {
     const struct sha256_digest zero = { { 0 } };
-    return memcmp(a, b, sizeof(struct sha256_digest))
-           || !memcmp(a, &zero, sizeof(struct sha256_digest));
+    return memcmp_constant_time(a, b, sizeof(struct sha256_digest))
+           || !memcmp_constant_time(a, &zero, sizeof(struct sha256_digest));
 }
 
 /**

--- a/src/openvpn/ssl_mbedtls.c
+++ b/src/openvpn/ssl_mbedtls.c
@@ -35,6 +35,7 @@
 
 #if defined(ENABLE_CRYPTO_MBEDTLS)
 
+#include "crypto.h"
 #include "errlevel.h"
 #include "ssl_backend.h"
 #include "base64.h"
@@ -1035,7 +1036,7 @@ tls_ctx_personalise_random(struct tls_root_ctx *ctx)
             msg(M_WARN, "WARNING: failed to personalise random");
         }
 
-        if (0 != memcmp(old_sha256_hash, sha256_hash, sizeof(sha256_hash)))
+        if (0 != memcmp_constant_time(old_sha256_hash, sha256_hash, sizeof(sha256_hash)))
         {
             if (!mbed_ok(mbedtls_ctr_drbg_update(cd_ctx, sha256_hash, 32)))
             {

--- a/src/openvpn/ssl_verify.c
+++ b/src/openvpn/ssl_verify.c
@@ -37,6 +37,7 @@
 #include "manage.h"
 #include "otime.h"
 #include "run_command.h"
+#include "crypto.h"
 #include "ssl_verify.h"
 #include "ssl_verify_backend.h"
 
@@ -241,7 +242,7 @@ cert_hash_compare(const struct cert_hash_set *chs1, const struct cert_hash_set *
                 continue;
             }
             else if (ch1 && ch2
-                     && !memcmp(ch1->sha256_hash, ch2->sha256_hash, sizeof(ch1->sha256_hash)))
+                     && !memcmp_constant_time(ch1->sha256_hash, ch2->sha256_hash, sizeof(ch1->sha256_hash)))
             {
                 continue;
             }


### PR DESCRIPTION
Three security-critical comparisons use `memcmp()` on SHA-256 digests where `memcmp_constant_time()` should be used:

- `ssl_verify.c:244` — certificate fingerprint comparison
- `ssl_mbedtls.c:1038` — TLS certificate hash comparison during renegotiation
- `init.c:2167-2168` — configuration digest comparison

The HMAC verification at `crypto.c:652` already uses `memcmp_constant_time` (CVE-2025-13086 fix). These three sites have the same pattern but were not updated.