### PR TITLE
proto: correct 802.1Q length check in is_ipv_X

### DIFF
--- a/src/openvpn/proto.c
+++ b/src/openvpn/proto.c
@@ -70,7 +70,7 @@ is_ipv_X(int tunnel_type, struct buffer *buf, int ip_ver)
         if (proto == htons(OPENVPN_ETH_P_8021Q))
         {
             const struct openvpn_8021qhdr *evh;
-            if (BLENZ(buf) < sizeof(struct openvpn_ethhdr) + sizeof(struct openvpn_iphdr))
+            if (BLENZ(buf) < sizeof(struct openvpn_8021qhdr) + sizeof(struct openvpn_iphdr))
             {
                 return false;
             }


### PR DESCRIPTION
In TAP mode is_ipv_X() checks an 802.1Q frame against the untagged Ethernet header size but then advances past the larger 18-byte 802.1Q header. A tagged frame of 34 to 37 bytes passes the check yet leaves fewer than sizeof(struct openvpn_iphdr) bytes at the new buffer head, so callers such as client_nat_transform that trust the return value access bytes past the IP header. Use sizeof(struct openvpn_8021qhdr) for the check instead.