### PR TITLE
ci: add read-only workflow token permissions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   clang-format:
     name: Check code style with clang-format

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -4,6 +4,9 @@ on:
     - cron: '0 20 * * *' # Daily at 20:00 UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   latest:
     # Running coverity requires the secrets.COVERITY_SCAN_TOKEN token

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches: ["master"]
   workflow_dispatch:
+permissions:
+  contents: read
+
 concurrency:
   group: "pages"
   cancel-in-progress: false

--- a/.github/workflows/test-ssllib.yml
+++ b/.github/workflows/test-ssllib.yml
@@ -1,5 +1,8 @@
 name: test_ssllib
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
## Summary

All four GitHub Actions workflows lacked an explicit workflow-level `permissions:` block. Without one, each run inherits the repository default GITHUB_TOKEN permissions, which can be broader than these jobs need.

This revision keeps the patch focused on workflow token permissions and sets the default token scope to read-only repository contents access.

### Changes

- `build.yaml`: add `permissions: contents: read`
- `coverity-scan.yml`: add `permissions: contents: read`
- `doxygen.yml`: add `permissions: contents: read`; the deploy job keeps its existing job-level `pages: write` and `id-token: write` permissions
- `test-ssllib.yml`: add `permissions: contents: read`

### Verification

```bash
python3 - <<'PY'
import pathlib, yaml
for p in pathlib.Path('.github/workflows').glob('*.yml'):
    yaml.safe_load(p.read_text())
for p in pathlib.Path('.github/workflows').glob('*.yaml'):
    yaml.safe_load(p.read_text())
print('yaml ok')
PY
```

Result: `yaml ok`.