### PR TITLE
push: guard AUTH_PENDING timeout calculation against unsigned underflow

### DIFF
--- a/src/openvpn/push.c
+++ b/src/openvpn/push.c
@@ -446,10 +446,14 @@ send_auth_pending_messages(struct tls_multi *tls_multi, struct tls_session *sess
     unsigned int proto = extract_iv_proto(peer_info);
 
 
-    /* Calculate the maximum timeout and subtract the time we already waited */
+    /* Calculate the maximum timeout and subtract the time we already waited.
+     * Guard against unsigned underflow: if more time has already elapsed
+     * than max_timeout allows, clamp to zero so the caller's timeout is
+     * also reduced to zero rather than wrapping to UINT_MAX. */
     unsigned int max_timeout =
         max_uint(tls_multi->opt.renegotiate_seconds / 2, tls_multi->opt.handshake_window);
-    max_timeout = max_timeout - (now - ks->initial);
+    unsigned int elapsed = (unsigned int)(now - ks->initial);
+    max_timeout = (elapsed < max_timeout) ? (max_timeout - elapsed) : 0;
     timeout = min_uint(max_timeout, timeout);
 
     struct gc_arena gc = gc_new();


### PR DESCRIPTION
## Problem

`send_auth_pending_messages()` calculates the remaining budget for the
AUTH_PENDING timeout by subtracting the elapsed key-state age from a
maximum derived from the renegotiation and handshake-window settings:

```c
unsigned int max_timeout =
    max_uint(tls_multi->opt.renegotiate_seconds / 2, tls_multi->opt.handshake_window);
max_timeout = max_timeout - (now - ks->initial);   // unsigned underflow here
timeout = min_uint(max_timeout, timeout);
```

Both operands are unsigned.  If the elapsed time exceeds `max_timeout`
(e.g. because a slow authentication back-end has already consumed the
entire window, or the clocks have shifted), the subtraction wraps around
to a value near `UINT_MAX`.  The subsequent `min_uint()` call then has no
effect, and the `AUTH_PENDING,timeout X` message sent to the peer carries
a timeout that is orders of magnitude larger than the intended security
window.  The peer may extend its handshake timeout accordingly, keeping
the connection in a pending-authentication state far beyond the configured
limit.

(The enclosing `#pragma GCC diagnostic ignored "-Wconversion"` block was
suppressing the compiler warning that would otherwise have flagged the
mixed signed/unsigned arithmetic here.)

## Fix

Compute the elapsed duration as a named `unsigned int` and use a
saturating subtraction: when `elapsed >= max_timeout` clamp `max_timeout`
to zero rather than wrapping it.

```c
unsigned int elapsed = (unsigned int)(now - ks->initial);
max_timeout = (elapsed < max_timeout) ? (max_timeout - elapsed) : 0;
timeout = min_uint(max_timeout, timeout);
```

An already-expired window is now correctly reported as zero remaining
time, and the `AUTH_PENDING` timeout sent to the peer is clamped
accordingly.