### PR TITLE
dns: Fix memory leak in dns_server_addr_parse

### DIFF
--- a/src/openvpn/dns.c
+++ b/src/openvpn/dns.c
@@ -114,13 +114,13 @@ dns_server_addr_parse(struct dns_server *server, const char *addr)
         addr = addrcopy;
     }
 
-    struct addrinfo *ai = NULL;
-    if (openvpn_getaddrinfo(0, addr, NULL, 0, NULL, af, &ai) != 0)
+    if (server->addr_count >= SIZE(server->addr))
     {
         return false;
     }
 
-    if (server->addr_count >= SIZE(server->addr))
+    struct addrinfo *ai = NULL;
+    if (openvpn_getaddrinfo(0, addr, NULL, 0, NULL, af, &ai) != 0)
     {
         return false;
     }


### PR DESCRIPTION
When parsing server addresses in dns_server_addr_parse(), if the DNS server's address count is already full (exceeds the limit of 8), the function returned early without freeing the successfully resolved addrinfo struct.
Fix this by moving the server->addr_count limit check above openvpn_getaddrinfo(), which avoids both the memory leak and the redundant DNS lookup.