### PR TITLE
openssl: avoid resetting the HMAC key on every packet

### DIFF
--- a/src/openvpn/crypto_openssl.c
+++ b/src/openvpn/crypto_openssl.c
@@ -1242,7 +1242,7 @@ hmac_ctx_final(HMAC_CTX *ctx, uint8_t *dst)
 
     HMAC_Final(ctx, dst, &in_hmac_len);
 }
-#else  /* if OPENSSL_VERSION_NUMBER < 0x30000000L */
+#else /* if OPENSSL_VERSION_NUMBER < 0x30000000L */
 hmac_ctx_t *
 hmac_ctx_new(void)
 {

--- a/src/openvpn/crypto_openssl.c
+++ b/src/openvpn/crypto_openssl.c
@@ -1308,10 +1308,14 @@ hmac_ctx_size(hmac_ctx_t *ctx)
 void
 hmac_ctx_reset(hmac_ctx_t *ctx)
 {
-    /* The OpenSSL MAC API lacks a reset method and passing NULL as params
-     * does not reset it either, so use the params array to reinitialise it the
-     * same way as before */
-    if (!EVP_MAC_init(ctx->ctx, NULL, 0, ctx->params))
+    /* OpenSSL 3.0.3 fixed EVP_MAC reinitialization with an existing key.
+     * Older versions need the parameters, including the key, to reset. */
+#if OPENSSL_VERSION_NUMBER >= 0x30000030L
+    const OSSL_PARAM *params = NULL;
+#else
+    const OSSL_PARAM *params = ctx->params;
+#endif
+    if (!EVP_MAC_init(ctx->ctx, NULL, 0, params))
     {
         crypto_msg(M_FATAL, "EVP_MAC_init failed");
     }


### PR DESCRIPTION
## Summary

- reinitialize OpenSSL 3.0.3+ HMAC contexts with their existing key
- retain the parameter-based path for OpenSSL 3.0.0 through 3.0.2

## Rationale

OpenVPN currently supplies the saved digest and key parameters on every `hmac_ctx_reset()`. The OpenSSL provider consequently reinstalls the same key and rebuilds the HMAC inner and outer digest states for every packet.

OpenSSL PR [#18100](https://github.com/openssl/openssl/pull/18100), included since 3.0.3, fixed parameterless `EVP_MAC_init()` reinitialization with an existing key. Using that path avoids the repeated setup without changing the key or output.

## Validation

- SHA-1 and RFC 2202 HMAC-SHA1 known-answer tests passed for repeated resets
- current and optimized paths produced identical output digests
- OpenVPN 2.7.5 cross-built successfully as an OpenWrt MIPS 24Kc package
- five-run median on MT7620A at a 1,500-byte message improved from 16.292 MB/s to 29.155 MB/s in an isolated HMAC benchmark

The existing `crypto_test_hmac()` also exercises context reset and verifies that changing the original key buffer after initialization does not change the result.