### PR TITLE
buffer: return false from buf_puts() on truncation

### DIFF
--- a/src/openvpn/buffer.c
+++ b/src/openvpn/buffer.c
@@ -252,15 +252,16 @@ buf_printf(struct buffer *buf, const char *format, ...)
 bool
 buf_puts(struct buffer *buf, const char *str)
 {
-    int ret = false;
+    bool ret = false;
     uint8_t *ptr = BEND(buf);
     int cap = buf_forward_capacity(buf);
     if (cap > 0)
     {
+        const size_t len = strlen(str);
         strncpynt((char *)ptr, str, cap);
         *(buf->data + buf->capacity - 1) = 0; /* windows vsnprintf needs this */
         buf->len += (int)strlen((char *)ptr);
-        ret = true;
+        ret = len < (size_t)cap;
     }
     return ret;
 }

--- a/tests/unit_tests/openvpn/test_buffer.c
+++ b/tests/unit_tests/openvpn/test_buffer.c
@@ -79,6 +79,26 @@ test_buffer_printf_catrunc(void **state)
 }
 
 static void
+test_buffer_puts(void **state)
+{
+    struct gc_arena gc = gc_new();
+    struct buffer buf = alloc_buf_gc(5, &gc);
+
+    assert_true(buf_puts(&buf, "1234"));
+    assert_string_equal(BSTR(&buf), "1234");
+
+    buf_reset_len(&buf);
+    assert_false(buf_puts(&buf, "12345"));
+    assert_string_equal(BSTR(&buf), "1234");
+
+    struct buffer one_byte_buf = alloc_buf_gc(1, &gc);
+    assert_false(buf_puts(&one_byte_buf, "x"));
+    assert_string_equal(BSTR(&one_byte_buf), "");
+
+    gc_free(&gc);
+}
+
+static void
 test_buffer_format_hex_ex(void **state)
 {
     const int input_size = 10;
@@ -572,6 +592,7 @@ main(void)
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_buffer_strprefix),
         cmocka_unit_test(test_buffer_printf_catrunc),
+        cmocka_unit_test(test_buffer_puts),
         cmocka_unit_test(test_buffer_format_hex_ex),
         cmocka_unit_test_setup_teardown(test_buffer_list_aggregate_separator_empty,
                                         test_buffer_list_setup, test_buffer_list_teardown),


### PR DESCRIPTION
# Thank you for your contribution

You are welcome to open PR, but they are used for discussion only. All
patches must eventually go to the openvpn-devel mailing list for review:

* https://lists.sourceforge.net/lists/listinfo/openvpn-devel

Please send your patch using [git-send-email](https://git-scm.com/docs/git-send-email). For example to send your latest commit to the list:

    $ git send-email --to=openvpn-devel@lists.sourceforge.net HEAD~1

For details, see these Wiki articles:

* https://community.openvpn.net/openvpn/wiki/DeveloperDocumentation
* https://community.openvpn.net/openvpn/wiki/Contributing



---



`buf_puts()` documents that it returns true when the string fits in the buffer and false when it is truncated.

However, the current implementation returns true whenever at least one byte of forward capacity remains. This is incorrect because `strncpynt()` may truncate the string to make room for the terminating NUL byte.

For example, with a 5-byte buffer:

```c
struct buffer buf = alloc_buf(5);
buf_puts(&buf, "12345");
```

the buffer contains `"1234"`, but `buf_puts()` currently returns true.

When only one byte of capacity remains, writing `"x"` stores an empty string and still returns true.



Measure the source string length before copying and return `len < cap`, where `cap` includes the terminating NUL byte.

This makes the return value match the documented API contract:

- `"1234"` in a 5-byte buffer returns true.
- `"12345"` in a 5-byte buffer returns false and stores `"1234"`.
- `"x"` in a 1-byte buffer returns false and stores an empty string.


