### PR TITLE
Fix spurious "CRL: cannot read CRL from file" warning on CRL reload

### DIFF
--- a/src/openvpn/ssl_openssl.c
+++ b/src/openvpn/ssl_openssl.c
@@ -1360,6 +1360,13 @@ backend_tls_ctx_reload_crl(struct tls_root_ctx *ssl_ctx, const char *crl_file, b
     }
 
     int num_crls_loaded = 0;
+    /*
+     * Start from an empty error queue so the EOF test below only sees errors
+     * raised by PEM_read_bio_X509_CRL(). A stale error left by an earlier
+     * operation in this thread would otherwise be what ERR_peek_error()
+     * returns, and a clean EOF gets reported as "cannot read CRL".
+     */
+    ERR_clear_error();
     while (true)
     {
         X509_CRL *crl = PEM_read_bio_X509_CRL(in, NULL, NULL, NULL);
@@ -1367,13 +1374,15 @@ backend_tls_ctx_reload_crl(struct tls_root_ctx *ssl_ctx, const char *crl_file, b
         {
             /*
              * PEM_R_NO_START_LINE can be considered equivalent to EOF.
+             * ERR_peek_last_error() is the error PEM_read_bio_X509_CRL()
+             * raised last; ERR_peek_error() would be the oldest queued one.
              */
-            bool eof = ERR_GET_REASON(ERR_peek_error()) == PEM_R_NO_START_LINE;
+            bool eof = ERR_GET_REASON(ERR_peek_last_error()) == PEM_R_NO_START_LINE;
             /* but warn if no CRLs have been loaded */
             if (num_crls_loaded > 0 && eof)
             {
                 /* remove that error from error stack */
-                (void)ERR_get_error();
+                ERR_clear_error();
                 break;
             }
 


### PR DESCRIPTION
Fixes #1103.

`backend_tls_ctx_reload_crl()` tests for end of file with `ERR_peek_error()`, which returns the oldest error on the thread's OpenSSL error queue, and never clears the queue first. Any error left queued earlier in the handshake makes a clean EOF after the last CRL look like a read failure: the `M_WARN` "CRL: cannot read CRL from file" fires with the unrelated queued errors printed under it, and the CRLs already parsed are installed anyway ("loaded 1 CRLs"). Seen on every first handshake after the CRL file changes, with OpenSSL 3.5.5 leaving an EVP "unsupported" error queued.

This change clears the queue before the read loop, tests `ERR_peek_last_error()`, and clears the queue on the EOF path instead of popping one entry.

Validated on aarch64 / OpenSSL 3.5.5 / DCO with two builds of master `28ec0f90` run as a server with `crl-verify <file>`, the file atomically replaced three times with a client re-handshake after each, then once with a file containing no CRL:

| build | spurious warning on reload | file with no CRL |
|---|---|---|
| unpatched | 3 of 3, stale EVP error printed with it | warns, `loaded 0 CRLs`, `VERIFY ERROR: CRL not loaded` |
| patched | 0 of 3 | warns, `loaded 0 CRLs`, `VERIFY ERROR: CRL not loaded`, prints only the PEM error |

Opened for review per CONTRIBUTING; the patch will go to openvpn-devel once ACKed. `clang-format --dry-run -Werror` is clean on the file.
